### PR TITLE
Switch auth from Discord to Twitter/GitHub

### DIFF
--- a/frontend/pages/api/auth/[...nextauth].ts
+++ b/frontend/pages/api/auth/[...nextauth].ts
@@ -57,11 +57,11 @@ export const authOptions: NextAuthOptions = {
       clientId: process.env.GITHUB_CLIENT_ID as string,
       clientSecret: process.env.GITHUB_CLIENT_SECRET as string,
     }),
-    // Discord OAuth provider
-    Discord({
-      clientId: process.env.DISCORD_CLIENT_ID as string,
-      clientSecret: process.env.DISCORD_CLIENT_SECRET as string,
-    }),
+    // // Discord OAuth provider
+    // Discord({
+    //   clientId: process.env.DISCORD_CLIENT_ID as string,
+    //   clientSecret: process.env.DISCORD_CLIENT_SECRET as string,
+    // }),
   ],
   // Custom page:
   pages: {

--- a/frontend/pages/api/claim/new.ts
+++ b/frontend/pages/api/claim/new.ts
@@ -18,11 +18,11 @@ import {
 import { privateKeyToAccount } from "viem/accounts";
 import { mainNetwork } from "@/utils/networks";
 import { whitelist, developerList } from "@/utils/whitelist";
-import { getDiscordMagnitude } from "@/utils/discord";
+// import { getDiscordMagnitude } from "@/utils/discord";
 
 const MIN_TWITTER_FOLLOWERS = 50;
 const MIN_GITHUB_FOLLOWERS = 10;
-const MIN_DISCORD_MAGNITUDE = 5;
+// const MIN_DISCORD_MAGNITUDE = 5;
 
 // Setup redis and slack clients
 const client = new Redis(process.env.REDIS_URL as string);
@@ -185,20 +185,20 @@ export default async (req: NextApiRequest, res: NextApiResponse) => {
     }
   }
 
-  // Validate Discord role (skip for whitelisted and developer users)
-  if (tier === "regular" && session.provider === "discord") {
-    const magnitude = await getDiscordMagnitude(session.discord_id!);
-    if (magnitude === null) {
-      return res.status(403).send({
-        error: "You must be a member of the Seismic Discord server to claim.",
-      });
-    }
-    if (magnitude < MIN_DISCORD_MAGNITUDE) {
-      return res.status(403).send({
-        error: `Minimum magnitude of ${MIN_DISCORD_MAGNITUDE} required. Your magnitude is ${magnitude}.`,
-      });
-    }
-  }
+  // // Validate Discord role (skip for whitelisted and developer users)
+  // if (tier === "regular" && session.provider === "discord") {
+  //   const magnitude = await getDiscordMagnitude(session.discord_id!);
+  //   if (magnitude === null) {
+  //     return res.status(403).send({
+  //       error: "You must be a member of the Seismic Discord server to claim.",
+  //     });
+  //   }
+  //   if (magnitude < MIN_DISCORD_MAGNITUDE) {
+  //     return res.status(403).send({
+  //       error: `Minimum magnitude of ${MIN_DISCORD_MAGNITUDE} required. Your magnitude is ${magnitude}.`,
+  //     });
+  //   }
+  // }
 
   // Validate address
   if (!address || !isAddress(address)) {

--- a/frontend/pages/index.tsx
+++ b/frontend/pages/index.tsx
@@ -102,8 +102,8 @@ export default function Home({
             <div className={styles.content__unauthenticated}>
               {/* Reasoning for OAuth */}
               <p>
-                To prevent faucet botting, you must sign in with Discord and have a magnitude role of 5 or higher. We request read-only access to verify your
-                account.
+                To prevent faucet botting, you must sign in with Twitter or
+                GitHub. We request read-only access to verify your account.
               </p>
 
               {/* Sign in buttons */}
@@ -114,7 +114,7 @@ export default function Home({
                   flexDirection: "column",
                 }}
               >
-                {/* <button
+                <button
                   className={styles.button__main}
                   onClick={() => signIn("twitter")}
                 >
@@ -125,13 +125,13 @@ export default function Home({
                   onClick={() => signIn("github")}
                 >
                   Sign In with GitHub
-                </button> */}
-                <button
+                </button>
+                {/* <button
                   className={styles.button__main}
                   onClick={() => signIn("discord")}
                 >
                   Sign In with Discord
-                </button>
+                </button> */}
               </div>
             </div>
           ) : (
@@ -219,9 +219,9 @@ export default function Home({
           <div className={styles.home__card_content_section}>
             <h4>General Information</h4>
             <p>
-              Sign in with Discord to claim ETH from the
-              faucet. Discord requires membership in the Seismic server with
-              a magnitude role of 5 or higher.
+              Sign in with Twitter or GitHub to claim ETH from the faucet.
+              Twitter requires {">"}50 followers, GitHub requires {">"}10
+              followers.
             </p>
             <p className={styles.home__card_content_section_lh}>
               The faucet drips ETH on your configured testnet. Each claim gives


### PR DESCRIPTION
## Summary
- Comment out Discord OAuth provider, sign-in button, and magnitude role validation
- Re-enable Twitter/X and GitHub sign-in buttons with follower-based gating
- Update UI copy to reflect Twitter (>50 followers) and GitHub (>10 followers) requirements
- All Discord code preserved as comments for easy revert

## Test plan
- [ ] Verify Twitter/X sign-in flow works end-to-end
- [ ] Verify GitHub sign-in flow works end-to-end
- [ ] Verify follower gating rejects accounts below threshold
- [ ] Confirm Discord sign-in button is not visible
- [ ] Confirm whitelisted users bypass follower checks