### PR TITLE
Add Fireblocks team to whitelist

### DIFF
--- a/frontend/utils/whitelist.ts
+++ b/frontend/utils/whitelist.ts
@@ -41,6 +41,11 @@ const ANKR_TEAM = [
   "165103466", // Felip (@fr-automator)
 ];
 
+// Fireblocks team GitHub IDs
+const FIREBLOCKS_TEAM = [
+  "207824728", // Tomer Shoham (@tomer-shoham)
+];
+
 /*
  * DEVELOPERS (2 ETH, 24h cooldown)
  */
@@ -68,6 +73,7 @@ export const whitelist = [
   ...CHAINLINK_TEAM,
   ...PIMLICO_TEAM,
   ...ANKR_TEAM,
+  ...FIREBLOCKS_TEAM,
   ...TWITTER_WHITELIST,
   ...DISCORD_WHITELIST,
 ];


### PR DESCRIPTION
## Summary
- Add Tomer Shoham (@tomer-shoham) from Fireblocks to the faucet whitelist (10 ETH, no cooldown)

🤖 Generated with [Claude Code](https://claude.com/claude-code)