### PR TITLE
Pin axios to 1.13.2 to mitigate supply chain attack

### DIFF
--- a/frontend/bun.lock
+++ b/frontend/bun.lock
@@ -28,6 +28,9 @@
       },
     },
   },
+  "overrides": {
+    "axios": "1.13.2",
+  },
   "packages": {
     "@adraffy/ens-normalize": ["@adraffy/ens-normalize@1.11.1", "", {}, "sha512-nhCBV3quEgesuf7c7KYfperqSS14T8bYuvJ8PcLJp6znkZpFc0AuW4qBtr8eKVyPPe/8RSr7sglCWPU5eaxwKQ=="],
 

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -27,6 +27,9 @@
     "seismic-viem": "1.1.0",
     "viem": "^2.40.2"
   },
+  "overrides": {
+    "axios": "1.13.2"
+  },
   "devDependencies": {
     "@types/ioredis": "^5.0.0",
     "@types/node": "^22.10.2",


### PR DESCRIPTION
## Summary
- Axios 1.14.1 was compromised in a supply chain attack (March 31, 2026) delivering a cross-platform RAT
- `@slack/web-api` pulls axios transitively via `^1.11.0`, which would resolve to the compromised version on next `bun install`
- Adds `overrides` entry pinning axios to 1.13.2 (current lockfile version) so installs are a no-op until resolved upstream

## Test plan
- [ ] Verify `bun install` resolves axios to 1.13.2
- [ ] Verify `bun pm ls | grep axios` shows 1.13.2

🤖 Generated with [Claude Code](https://claude.com/claude-code)