### PR TITLE
add Henry to Seismic team GH whitelist

### DIFF
--- a/community-frontend/utils/whitelist.ts
+++ b/community-frontend/utils/whitelist.ts
@@ -11,6 +11,7 @@ const SEISMIC_TEAM = [
   "30359739", // Lyron Co Ting Keh (@lyronctk)
   "57149625", // Matt Haines (@mHaines9219)
   "9342524", // Sam Laferriere (@samlaf)
+  "67980579", // Henry Baldwin (@HenryMBaldwin)
 ];
 
 // Brookwell team GitHub IDs

--- a/frontend/utils/whitelist.ts
+++ b/frontend/utils/whitelist.ts
@@ -11,6 +11,7 @@ const SEISMIC_TEAM = [
   "30359739", // Lyron Co Ting Keh (@lyronctk)
   "57149625", // Matt Haines (@mHaines9219)
   "9342524", // Sam Laferriere (@samlaf)
+  "67980579", // Henry Baldwin (@HenryMBaldwin)
 ];
 
 // Brookwell team GitHub IDs


### PR DESCRIPTION
## Summary

Adds **Henry Baldwin** (@HenryMBaldwin, GitHub ID `67980579`) to the Seismic team entry in both `frontend/utils/whitelist.ts` and `community-frontend/utils/whitelist.ts`.

Whitelisted users bypass the GitHub follower threshold and receive 250 SUSDC per claim with no 24h cooldown.

## Test plan

- [ ] Next rebuild of `frontend/` and `community-frontend/` picks up the new entry
- [ ] Henry can sign in via GitHub and claim 250 SUSDC without a follower-count check