### PR TITLE
add Anchorage team to GH whitelist

### DIFF
--- a/community-frontend/utils/whitelist.ts
+++ b/community-frontend/utils/whitelist.ts
@@ -47,6 +47,11 @@ const FIREBLOCKS_TEAM = [
   "207824728", // Tomer Shoham (@tomer-shoham)
 ];
 
+// Anchorage team GitHub IDs
+const ANCHORAGE_TEAM = [
+  "272382493", // Rodrigo Nascimento (@rodrigonascimento-anchorlabs)
+];
+
 /*
  * DEVELOPERS (50 SUSDC, 24h cooldown)
  */
@@ -75,6 +80,7 @@ export const whitelist = [
   ...PIMLICO_TEAM,
   ...ANKR_TEAM,
   ...FIREBLOCKS_TEAM,
+  ...ANCHORAGE_TEAM,
   ...TWITTER_WHITELIST,
   ...DISCORD_WHITELIST,
 ];

--- a/frontend/utils/whitelist.ts
+++ b/frontend/utils/whitelist.ts
@@ -47,6 +47,11 @@ const FIREBLOCKS_TEAM = [
   "207824728", // Tomer Shoham (@tomer-shoham)
 ];
 
+// Anchorage team GitHub IDs
+const ANCHORAGE_TEAM = [
+  "272382493", // Rodrigo Nascimento (@rodrigonascimento-anchorlabs)
+];
+
 /*
  * DEVELOPERS (50 SUSDC, 24h cooldown)
  */
@@ -75,6 +80,7 @@ export const whitelist = [
   ...PIMLICO_TEAM,
   ...ANKR_TEAM,
   ...FIREBLOCKS_TEAM,
+  ...ANCHORAGE_TEAM,
   ...TWITTER_WHITELIST,
   ...DISCORD_WHITELIST,
 ];


### PR DESCRIPTION
## Summary

Adds a new `ANCHORAGE_TEAM` section to both `frontend/utils/whitelist.ts` and `community-frontend/utils/whitelist.ts`.

- **Rodrigo Nascimento** (@rodrigonascimento-anchorlabs, GitHub ID `272382493`)

Whitelisted users bypass the GitHub follower threshold and receive 250 SUSDC per claim with no 24h cooldown.

## Test plan

- [ ] Next rebuild of `frontend/` (and optionally `community-frontend/`) picks up the new entry
- [ ] Rodrigo can sign in via GitHub on the main faucet and claim 250 SUSDC without a follower-count check