### PR TITLE
add Den team to GitHub whitelist

### DIFF
--- a/community-frontend/utils/whitelist.ts
+++ b/community-frontend/utils/whitelist.ts
@@ -52,6 +52,11 @@ const ANCHORAGE_TEAM = [
   "272382493", // Rodrigo Nascimento (@rodrigonascimento-anchorlabs)
 ];
 
+// Den team GitHub IDs
+const DEN_TEAM = [
+  "8534926", // Jonah Erlich (@jierlich)
+];
+
 /*
  * DEVELOPERS (50 SUSDC, 24h cooldown)
  */
@@ -81,6 +86,7 @@ export const whitelist = [
   ...ANKR_TEAM,
   ...FIREBLOCKS_TEAM,
   ...ANCHORAGE_TEAM,
+  ...DEN_TEAM,
   ...TWITTER_WHITELIST,
   ...DISCORD_WHITELIST,
 ];

--- a/frontend/utils/whitelist.ts
+++ b/frontend/utils/whitelist.ts
@@ -52,6 +52,11 @@ const ANCHORAGE_TEAM = [
   "272382493", // Rodrigo Nascimento (@rodrigonascimento-anchorlabs)
 ];
 
+// Den team GitHub IDs
+const DEN_TEAM = [
+  "8534926", // Jonah Erlich (@jierlich)
+];
+
 /*
  * DEVELOPERS (50 SUSDC, 24h cooldown)
  */
@@ -81,6 +86,7 @@ export const whitelist = [
   ...ANKR_TEAM,
   ...FIREBLOCKS_TEAM,
   ...ANCHORAGE_TEAM,
+  ...DEN_TEAM,
   ...TWITTER_WHITELIST,
   ...DISCORD_WHITELIST,
 ];


### PR DESCRIPTION
## Summary
- Add `DEN_TEAM` with Jonah Erlich (@jierlich, GitHub ID `8534926`) at the trusted whitelist tier (250 SUSDC, no cooldown)
- Mirrored across both `frontend/utils/whitelist.ts` and `community-frontend/utils/whitelist.ts`

## Test plan
- [x] Confirm jierlich's GitHub login resolves to ID `8534926` on the live faucet
- [x] Verify a claim from his account drips 250 SUSDC and bypasses the cooldown