### PR TITLE
fix: replace weak JWT secret placeholder in .env.sample

### DIFF
--- a/community-frontend/.env.sample
+++ b/community-frontend/.env.sample
@@ -1,6 +1,7 @@
 REDIS_URL=""
 NEXTAUTH_URL="http://localhost:3001"
-NEXTAUTH_JWT_SECRET="thisisatestsecret"
+# Generate a strong secret with: openssl rand -hex 32
+NEXTAUTH_JWT_SECRET=""
 DISCORD_CLIENT_ID=""
 DISCORD_CLIENT_SECRET=""
 DISCORD_BOT_TOKEN=""

--- a/frontend/.env.sample
+++ b/frontend/.env.sample
@@ -1,6 +1,7 @@
 REDIS_URL=""
 NEXTAUTH_URL="http://localhost:3000"
-NEXTAUTH_JWT_SECRET="thisisatestsecret"
+# Generate a strong secret with: openssl rand -hex 32
+NEXTAUTH_JWT_SECRET=""
 TWITTER_CLIENT_ID=""
 TWITTER_CLIENT_SECRET=""
 NEXT_PUBLIC_OPERATOR_ADDRESS=""


### PR DESCRIPTION
## Summary

Both `frontend/.env.sample` and `community-frontend/.env.sample` ship with `NEXTAUTH_JWT_SECRET="thisisatestsecret"` as the placeholder value. Because sample files are commonly copied to `.env` and committed/deployed unchanged, a developer who forgets to regenerate the secret ends up signing production JWTs with a short, guessable string.

This PR makes the misconfiguration **fail loudly** rather than silently.

## Changes

- Replace the literal `"thisisatestsecret"` with an empty string so NextAuth throws on startup when the secret is not set, surfacing the issue early.
- Add a one-line comment with the recommended generation command (`openssl rand -hex 32`), so developers know what to put there.

Applied symmetrically to both `frontend/` and `community-frontend/` for consistency.

## Diff

```env
# Generate a strong secret with: openssl rand -hex 32
NEXTAUTH_JWT_SECRET=""
```

## Rationale

`.env.sample` is, by design, the first thing a new contributor copies. A non-empty default has two failure modes:

1. **Local dev → leaked dev secrets.** If a developer treats `.env.sample` as a working dev config, every developer ends up with the same key.
2. **Sample → production.** If the sample is copied to a deploy target without review, JWTs are signed with `"thisisatestsecret"`, which is trivially compromisable.

An empty string forces an explicit decision. The comment removes the "but how do I generate one?" friction.

## Out of scope

- No code changes — this is a docs/config-only fix.
- No changes to `frontend/utils/whitelist.ts`, OAuth providers, or any other secret handling. Happy to follow up on those as separate PRs if desired.

## Testing

`.env.sample` files are not loaded at runtime; this change is purely a template update. Verified locally that the diff touches only the intended two files and only the intended lines.