### PR TITLE
contracts:deploy: pass --unsafe-private-storage to sforge script

### DIFF
--- a/community-frontend/package.json
+++ b/community-frontend/package.json
@@ -11,7 +11,7 @@
     "lint": "bun run next lint",
     "contracts:compile": "bun run --cwd ../contracts sforge build",
     "contracts:test": "bun run --cwd ../contracts sforge test",
-    "contracts:deploy": "source .env && RPC_URL=$RPC_URL FAUCET_PRIVATE_KEY=$FAUCET_PRIVATE_KEY FAUCET_RESERVE_PRIVATE_KEY=$FAUCET_RESERVE_PRIVATE_KEY SUSDC_ADDRESS=$SUSDC_ADDRESS bun run --cwd ../contracts sforge script script/Deploy.s.sol --rpc-url $RPC_URL --broadcast --private-key $FAUCET_PRIVATE_KEY"
+    "contracts:deploy": "source .env && RPC_URL=$RPC_URL FAUCET_PRIVATE_KEY=$FAUCET_PRIVATE_KEY FAUCET_RESERVE_PRIVATE_KEY=$FAUCET_RESERVE_PRIVATE_KEY SUSDC_ADDRESS=$SUSDC_ADDRESS bun run --cwd ../contracts sforge script script/Deploy.s.sol --rpc-url $RPC_URL --broadcast --private-key $FAUCET_PRIVATE_KEY --unsafe-private-storage"
   },
   "dependencies": {
     "@slack/web-api": "^7.10.0",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -11,7 +11,7 @@
     "lint": "bun run next lint",
     "contracts:compile": "bun run --cwd ../contracts sforge build",
     "contracts:test": "bun run --cwd ../contracts sforge test",
-    "contracts:deploy": "source .env && RPC_URL=$RPC_URL FAUCET_PRIVATE_KEY=$FAUCET_PRIVATE_KEY FAUCET_RESERVE_PRIVATE_KEY=$FAUCET_RESERVE_PRIVATE_KEY SUSDC_ADDRESS=$SUSDC_ADDRESS bun run --cwd ../contracts sforge script script/Deploy.s.sol --rpc-url $RPC_URL --broadcast --private-key $FAUCET_PRIVATE_KEY"
+    "contracts:deploy": "source .env && RPC_URL=$RPC_URL FAUCET_PRIVATE_KEY=$FAUCET_PRIVATE_KEY FAUCET_RESERVE_PRIVATE_KEY=$FAUCET_RESERVE_PRIVATE_KEY SUSDC_ADDRESS=$SUSDC_ADDRESS bun run --cwd ../contracts sforge script script/Deploy.s.sol --rpc-url $RPC_URL --broadcast --private-key $FAUCET_PRIVATE_KEY --unsafe-private-storage"
   },
   "dependencies": {
     "@slack/web-api": "^7.10.0",


### PR DESCRIPTION
## Summary
`bun run contracts:deploy` on a fresh checkout fails during script simulation:

```
Error: EVM error
Context:
- database error: attempted to read private storage slot 2 at address 0x7907...43. Use --unsafe-private-storage to allow this.
```

`Deploy.s.sol` admin-mints SUSDC into the new faucet, so the fork simulation must read the token's shielded (`suint256`) balance slots, which sforge blocks by default.

## Change
Append `--unsafe-private-storage` to the `contracts:deploy` script in both `frontend/package.json` and `community-frontend/package.json`. Affects only local simulation — the broadcast tx is unchanged.

Hit while redeploying the faucet for the AWS → GCP migration (2026-07-23); verified the flag unblocks the deploy against testnet-0.