### PR TITLE
chore(contracts): bump seismic-std-lib to 0.2.0

### DIFF
--- a/contracts/foundry.toml
+++ b/contracts/foundry.toml
@@ -12,4 +12,4 @@ remappings = [
 # See more config options https://github.com/foundry-rs/foundry/blob/master/crates/config/README.md#all-options
 
 [dependencies]
-seismic-std-lib = "0.1.4"
+seismic-std-lib = "0.2.0"

--- a/contracts/remappings.txt
+++ b/contracts/remappings.txt
@@ -1,2 +1,2 @@
-seismic-std-lib-0.1.4/=dependencies/seismic-std-lib-0.1.4/
-seismic-std-lib/=dependencies/seismic-std-lib-0.1.4/
+seismic-std-lib-0.2.0/=dependencies/seismic-std-lib-0.2.0/
+seismic-std-lib/=dependencies/seismic-std-lib-0.2.0/

--- a/contracts/soldeer.lock
+++ b/contracts/soldeer.lock
@@ -1,6 +1,6 @@
 [[dependencies]]
 name = "seismic-std-lib"
-version = "0.1.4"
-url = "https://soldeer-revisions.s3.amazonaws.com/seismic-std-lib/0_1_4_09-04-2026_11:00:23_seismic-std-lib.zip"
-checksum = "b167ff9c3a02a84bb2d6ba036ab31e448a059d81c3124bb58cde93dd421a9edb"
-integrity = "c5044550aeb7a2f03e97bd5e45db2a29be1b5cf072659686227a3089e6392f0a"
+version = "0.2.0"
+url = "https://soldeer-revisions.s3.amazonaws.com/seismic-std-lib/0_2_0_31-07-2026_11:12:06_seismic-std-lib.zip"
+checksum = "5b7bae55eab4b87e71c948c2d3fda81dbea1d29729bb56c19f012f1b317c92ea"
+integrity = "0b11b9a35a33a1990808d0ca1e82055563bdea7601557b3dd15ddf31b034db76"


### PR DESCRIPTION
Bumps `seismic-std-lib` from the pre-audit release to **0.2.0**, the first published version containing the Zellic remediation fixes (monorepo PR #212).

## What 0.2.0 changes

| Finding | Change |
|---|---|
| 3.3 (High) | `SRC20.balanceOfSigned` — personal-sign digest → EIP-712 bound to `chainId` |
| 3.1 (High) | `Directory` draws a random nonce per encrypt; `IDirectory.nonce()` removed |
| 3.6 (Info) | `SRC20Multicall.batchBalancesDetailed` treats a non-32-byte return as failure |

## Impact here

None of this repo's contracts call `balanceOfSigned` or `IDirectory`, so this is a dependency bump with no behavioural change. `ShieldedDelegationAccount` — the contract this repo actually consumes — is **byte-identical** between the old pin and 0.2.0; the only other delta is two purely additive files (`SRC20Token.sol`, `SRC20Factory.sol`).

## Test plan

- `soldeer.lock` regenerated; checksum `5b7bae55…92ea` matches the published artifact, which was verified byte-identical to monorepo `main` (minus the `.soldeerignore`-excluded `CLAUDE.md`).
- `sforge build --force` — exit 0, zero errors. Only the usual advisory warnings (10311/10301/3805) from inside `dependencies/seismic-std-lib-0.2.0/`.
- Verified on sforge 1.3.5-v0.3.0.