### PR TITLE
deploy: run Redis locally under supervisor instead of remote instance

### DIFF
--- a/deploy/redis.conf
+++ b/deploy/redis.conf
@@ -1,0 +1,6 @@
+bind 127.0.0.1
+port 6379
+supervised no
+dir /home/ubuntu/faucet/redis-data
+appendonly yes
+appendfilename "appendonly.aof"

--- a/deploy/supervisor.conf
+++ b/deploy/supervisor.conf
@@ -1,3 +1,18 @@
+[program:redis]
+command=/usr/bin/redis-server /home/ubuntu/faucet/deploy/redis.conf
+directory=/home/ubuntu/faucet
+user=ubuntu
+autostart=true
+autorestart=true
+startsecs=5
+startretries=3
+priority=1
+stderr_logfile=/var/log/faucet/redis.err.log
+stdout_logfile=/var/log/faucet/redis.out.log
+redirect_stderr=true
+stopasgroup=true
+killasgroup=true
+
 [program:faucet-frontend]
 command=/home/ubuntu/.bun/bin/bun start
 directory=/home/ubuntu/faucet/frontend


### PR DESCRIPTION
## Summary
- Remote `REDIS_URL` was hitting `ETIMEDOUT` on the faucet box, hanging every claim request (stuck "Claiming...") and then tripping the 15-min rate-limit cooldown on failure — reported by a user via Slack, filed as SEI-129.
- Adds a supervised `redis-server` program (`deploy/supervisor.conf`) with a minimal config (`deploy/redis.conf`) enabling AOF persistence, bound to `127.0.0.1:6379`.
- Both faucet apps already run on this single box, so a local Redis removes the external network dependency that caused the outage. No app code changes — `REDIS_URL` still needs to be pointed at `127.0.0.1:6379` on the box itself (not part of this diff, done via `.env`).

## Test plan
- [x] Deploy to box, run the setup commands (see below), confirm `supervisorctl status` shows `redis` RUNNING before the two frontend programs
- [x] Update `REDIS_URL=redis://127.0.0.1:6379` in both `frontend/.env` and `community-frontend/.env`, restart both frontend programs
- [x] Claim from a test account, confirm no more `ETIMEDOUT` in `/var/log/faucet/*.out.log`
- [x] Restart supervisor, confirm rate-limit/nonce keys persisted (AOF)

Closes SEI-129.