### PR TITLE
community-frontend: lower minimum Discord magnitude to claim from 5 to 1

### DIFF
--- a/community-frontend/pages/api/claim/new.ts
+++ b/community-frontend/pages/api/claim/new.ts
@@ -20,7 +20,7 @@ import { mainNetwork } from "@/utils/networks";
 import { whitelist, developerList } from "@/utils/whitelist";
 import { getDiscordMagnitude } from "@/utils/discord";
 
-const MIN_DISCORD_MAGNITUDE = 5;
+const MIN_DISCORD_MAGNITUDE = 1;
 
 // Setup redis and slack clients
 const client = new Redis(process.env.REDIS_URL as string);

--- a/community-frontend/pages/index.tsx
+++ b/community-frontend/pages/index.tsx
@@ -205,7 +205,7 @@ export default function Home({
             <p>
               Sign in with Discord to claim SUSDC from the faucet. You must be
               a member of the Seismic Discord and hold a magnitude role of at
-              least 5.
+              least 1.
             </p>
             <p className={styles.home__card_content_section_lh}>
               The faucet drips SUSDC on your configured testnet. Each claim


### PR DESCRIPTION
## Summary
- Lower `MIN_DISCORD_MAGNITUDE` in `community-frontend/pages/api/claim/new.ts` from 5 to 1
- Update the claim eligibility copy on `community-frontend/pages/index.tsx` to match (magnitude role of at least 1)

## Test plan
- [ ] Verify a Discord user with only a magnitude 1+ role can successfully claim
- [ ] Verify a user with no magnitude role is still rejected