### PR TITLE
fix: apply the same nonce lock to community-frontend (shares the same operator wallet/chain as frontend)

### DIFF
--- a/community-frontend/pages/api/claim/new.ts
+++ b/community-frontend/pages/api/claim/new.ts
@@ -71,6 +71,48 @@ async function getNonceForChain(
   return await publicClient.getTransactionCount({ address: operatorAddress });
 }
 
+// Redis-based mutex so two concurrent drips on the same chain can never read
+// and reserve the same nonce. Without this, getNonceForChain's read (GET) and
+// processDrip's write (SET nonce+1) race: two requests can both read the same
+// cached nonce before either writes the increment, so both transactions get
+// sent with the same nonce. One of them silently fails/gets dropped on-chain,
+// while claim/new.ts still reports success and applies the 24h cooldown to
+// that user, so they never actually receive tokens.
+//
+// This lock key is shared with frontend/pages/api/claim/new.ts on purpose:
+// both apps drive the same operator wallet against the same chain (see
+// utils/networks.ts, identical in both apps), so a lock scoped to only one
+// app would not prevent a race between a request handled by this app and one
+// handled by the other.
+const NONCE_LOCK_TTL_MS = 10_000;
+const NONCE_LOCK_MAX_WAIT_MS = 5_000;
+const NONCE_LOCK_RETRY_DELAY_MS = 100;
+
+async function acquireNonceLock(chainName: string): Promise<string | null> {
+  const lockKey = `nonce-lock-${chainName}`;
+  const token = `${Date.now()}-${Math.random().toString(36).slice(2)}`;
+  const deadline = Date.now() + NONCE_LOCK_MAX_WAIT_MS;
+
+  while (Date.now() < deadline) {
+    const ok = await client.set(lockKey, token, "PX", NONCE_LOCK_TTL_MS, "NX");
+    if (ok === "OK") {
+      return token;
+    }
+    await new Promise((resolve) => setTimeout(resolve, NONCE_LOCK_RETRY_DELAY_MS));
+  }
+
+  return null;
+}
+
+async function releaseNonceLock(chainName: string, token: string): Promise<void> {
+  const lockKey = `nonce-lock-${chainName}`;
+  // Only release if we still hold the lock (avoid deleting a lock that
+  // expired and was re-acquired by someone else in the meantime).
+  const script =
+    'if redis.call("get", KEYS[1]) == ARGV[1] then return redis.call("del", KEYS[1]) else return 0 end';
+  await client.eval(script, 1, lockKey, token);
+}
+
 async function processDrip(
   account: ReturnType<typeof privateKeyToAccount>,
   chain: Chain,
@@ -92,34 +134,45 @@ async function processDrip(
     transport: http(),
   });
 
-  const nonce = await getNonceForChain(chain, account.address);
-  const gasPrice = await publicClient.getGasPrice();
-
-  console.log(`[processDrip] Nonce: ${nonce}, Gas price: ${gasPrice}`);
-
-  // Update nonce in redis with 5m TTL
-  await client.set(`nonce-${chain.name}`, nonce + 1, "EX", 300);
+  const lockToken = await acquireNonceLock(chain.name);
+  if (!lockToken) {
+    throw new Error(
+      `Timed out waiting for nonce lock on ${chain.name}; another drip is in progress`,
+    );
+  }
 
   try {
-    console.log(`[processDrip] Sending transaction...`);
-    const txHash = await walletClient.sendTransaction({
-      to: faucetAddress,
-      data,
-      gasPrice: gasPrice * BigInt(2),
-      gas: BigInt(500_000),
-      nonce,
-    });
-    console.log(`[processDrip] Transaction sent! Hash: ${txHash}`);
-  } catch (e: any) {
-    console.error(`[processDrip] ERROR: ${e.message || String(e)}`);
-    const errorMsg = `Error dripping for ${chain.name}: ${e.message || String(e)}`;
-    await postSlackMessage(errorMsg);
+    const nonce = await getNonceForChain(chain, account.address);
+    const gasPrice = await publicClient.getGasPrice();
 
-    // Attempt self-heal by clearing nonce
-    await client.del(`nonce-${chain.name}`);
-    await postSlackMessage(`Attempting self heal for ${chain.name}`);
+    console.log(`[processDrip] Nonce: ${nonce}, Gas price: ${gasPrice}`);
 
-    throw new Error(`Error when processing drip for ${chain.name}`);
+    // Update nonce in redis with 5m TTL
+    await client.set(`nonce-${chain.name}`, nonce + 1, "EX", 300);
+
+    try {
+      console.log(`[processDrip] Sending transaction...`);
+      const txHash = await walletClient.sendTransaction({
+        to: faucetAddress,
+        data,
+        gasPrice: gasPrice * BigInt(2),
+        gas: BigInt(500_000),
+        nonce,
+      });
+      console.log(`[processDrip] Transaction sent! Hash: ${txHash}`);
+    } catch (e: any) {
+      console.error(`[processDrip] ERROR: ${e.message || String(e)}`);
+      const errorMsg = `Error dripping for ${chain.name}: ${e.message || String(e)}`;
+      await postSlackMessage(errorMsg);
+
+      // Attempt self-heal by clearing nonce
+      await client.del(`nonce-${chain.name}`);
+      await postSlackMessage(`Attempting self heal for ${chain.name}`);
+
+      throw new Error(`Error when processing drip for ${chain.name}`);
+    }
+  } finally {
+    await releaseNonceLock(chain.name, lockToken);
   }
 }
 


### PR DESCRIPTION
Follow-up to #29. community-frontend/pages/api/claim/new.ts has the exact
same getNonceForChain/processDrip pattern as frontend, with the same
unprotected GET-then-SET nonce race.

More importantly: frontend/utils/networks.ts and
community-frontend/utils/networks.ts are identical, so both apps drive the
same operator wallet against the same mainNetwork chain, and use the same
`nonce-${chain.name}` Redis cache key. A lock scoped to only one of the two
apps (as in #29) would not prevent a race between a request handled by
frontend and one handled by community-frontend at the same time — the lock
key here is intentionally the same (`nonce-lock-${chain.name}`) so both
apps serialize against each other, not just against themselves.

Same fix as #29, applied here for consistency and actual protection across
both frontends.