### PR TITLE
fix: never let postSlackMessage failures break the drip path

### DIFF
--- a/community-frontend/pages/api/claim/new.ts
+++ b/community-frontend/pages/api/claim/new.ts
@@ -28,11 +28,19 @@ const slack = new WebClient(process.env.SLACK_ACCESS_TOKEN);
 const slackChannel = process.env.SLACK_CHANNEL ?? "";
 
 async function postSlackMessage(message: string): Promise<void> {
-  await slack.chat.postMessage({
-    channel: slackChannel,
-    text: message,
-    link_names: true,
-  });
+  try {
+    await slack.chat.postMessage({
+      channel: slackChannel,
+      text: message,
+      link_names: true,
+    });
+  } catch (e: any) {
+    // Alerting must never break dripping: callers invoke this inside the drip
+    // catch block before the nonce self-heal, so a throw here would skip it.
+    console.error(
+      `[postSlackMessage] Failed to post to Slack: ${e.message || String(e)}`,
+    );
+  }
 }
 
 type UserTier = "whitelist" | "developer" | "regular";

--- a/frontend/pages/api/claim/new.ts
+++ b/frontend/pages/api/claim/new.ts
@@ -29,11 +29,19 @@ const slack = new WebClient(process.env.SLACK_ACCESS_TOKEN);
 const slackChannel = process.env.SLACK_CHANNEL ?? "";
 
 async function postSlackMessage(message: string): Promise<void> {
-  await slack.chat.postMessage({
-    channel: slackChannel,
-    text: message,
-    link_names: true,
-  });
+  try {
+    await slack.chat.postMessage({
+      channel: slackChannel,
+      text: message,
+      link_names: true,
+    });
+  } catch (e: any) {
+    // Alerting must never break dripping: callers invoke this inside the drip
+    // catch block before the nonce self-heal, so a throw here would skip it.
+    console.error(
+      `[postSlackMessage] Failed to post to Slack: ${e.message || String(e)}`,
+    );
+  }
 }
 
 type UserTier = "whitelist" | "developer" | "regular";


### PR DESCRIPTION
## Summary

`postSlackMessage` is awaited inside `processDrip`'s catch block **before** the nonce self-heal (`client.del("nonce-…")`). If the Slack call itself throws — rate limit, revoked token, network blip — the self-heal is skipped and a stale nonce stays cached for up to 5 minutes.

This wraps the body of `postSlackMessage` in try/catch with a `console.error` fallback so alerting can never break dripping. Same fix in both apps, since `community-frontend` has an identical copy.

## Changes

- `frontend/pages/api/claim/new.ts` — swallow + log Slack errors in `postSlackMessage`
- `community-frontend/pages/api/claim/new.ts` — same

## Context

Prerequisite for actually wiring Slack alerts (setting `SLACK_ACCESS_TOKEN`/`SLACK_CHANNEL`): today the vars are unset so the call sites are dormant; once live, a Slack outage mid-drip-failure would compound the nonce-cache problem instead of reporting it. Related: #29 / #30 address the underlying nonce race itself.

## Test plan

- Parse-checked both files with `bun build`
- Behavior change is limited to the error path of an alerting helper; drip logic untouched