### PR TITLE
deploy: cap Next.js heap at 2G to prevent whole-box OOM

### DIFF
--- a/deploy/supervisor.conf
+++ b/deploy/supervisor.conf
@@ -23,7 +23,7 @@ startsecs=10
 startretries=3
 stderr_logfile=/var/log/faucet/frontend.err.log
 stdout_logfile=/var/log/faucet/frontend.out.log
-environment=NODE_ENV=production,PATH="/home/ubuntu/.bun/bin:/usr/local/bin:/usr/bin:/bin"
+environment=NODE_ENV=production,NODE_OPTIONS="--max-old-space-size=2048",PATH="/home/ubuntu/.bun/bin:/usr/local/bin:/usr/bin:/bin"
 stopasgroup=true
 killasgroup=true
 redirect_stderr=true
@@ -38,7 +38,7 @@ startsecs=10
 startretries=3
 stderr_logfile=/var/log/faucet/discord-frontend.err.log
 stdout_logfile=/var/log/faucet/discord-frontend.out.log
-environment=NODE_ENV=production,PATH="/home/ubuntu/.bun/bin:/usr/local/bin:/usr/bin:/bin"
+environment=NODE_ENV=production,NODE_OPTIONS="--max-old-space-size=2048",PATH="/home/ubuntu/.bun/bin:/usr/local/bin:/usr/bin:/bin"
 stopasgroup=true
 killasgroup=true
 redirect_stderr=true


### PR DESCRIPTION
## Summary

Caps the V8 heap of both Next.js frontends (`faucet-frontend`, `faucet-discord-frontend`) at 2 GB via `NODE_OPTIONS="--max-old-space-size=2048"` in `deploy/supervisor.conf`, so a leaking frontend crashes and gets restarted by supervisor instead of taking down the whole box.

## Why — root cause of the Aug 15–18 faucet outage

The faucet box (`faucet.seismictest.net`, GCP `testnet-477314/faucet`, 7.8 GB RAM, no swap) was unreachable on every port until it was reset on Aug 18. Forensics from the previous boot's journal:

1. One of the Next.js frontends leaks memory: node RSS grows unbounded (observed at ~2.9 GB when killed, ~76 GB virtual).
2. **Aug 15 04:51** — the kernel's global OOM killer shot the node process. Because it lives in the `supervisor.service` cgroup, systemd marked the *entire unit* `Failed with result 'oom-kill'` and stopped it — but the node child processes survived the stop (`Unit process remains running after unit stopped`).
3. `Restart=on-failure` respawned supervisord 50s later, which started *fresh* frontends alongside the orphaned ones. By the **Aug 17 19:29** restart, systemd found **six leftover node processes** in the cgroup and the unit's memory peak hit **7.3 GB of 7.8 GB** — a duplication death spiral, second global OOM kill (this one severe enough that `systemd-journald` itself invoked the OOM killer).
4. Somewhere in this window the guest also lost networking (metadata server unreachable from Aug 14 onward), which is why the box appeared completely dead from outside — no SSH, no HTTP, no ping — while supervisord kept cycling internally.

With this change, a leaking frontend aborts at ~2 GB of heap and supervisor's `autorestart`/`killasgroup` restarts just that program cleanly. The kernel OOM killer never fires, `supervisor.service` never gets failed by systemd, and no orphan processes accumulate.

## Deployment

The conf on the box must be updated to match and the frontends restarted:

```sh
sudo cp deploy/supervisor.conf /etc/supervisor/conf.d/faucet.conf
sudo supervisorctl reread && sudo supervisorctl update
sudo supervisorctl restart faucet-frontend faucet-discord-frontend
```

## Follow-ups (out of scope here)

- Add swap to the box (2 G thrash buffer) so SSH survives future memory pressure.
- Find the actual leak — compare `ps -o pid,rss,etime,args -C node` over a few days to identify which frontend is leaking and why.
- Root-cause the guest network loss (metadata route gone from Aug 14; possibly lease renewal failing under memory pressure).
- External uptime monitoring on `https://faucet.seismictest.net` — this outage was discovered by a user days after it began.
