### PR TITLE
fix: fail fast on unreachable redis instead of pinning requests in memory

### DIFF
--- a/community-frontend/pages/api/claim/new.ts
+++ b/community-frontend/pages/api/claim/new.ts
@@ -1,4 +1,4 @@
-import Redis from "ioredis";
+import { redis as client } from "@/utils/redis";
 import { WebClient } from "@slack/web-api";
 import { getServerSession } from "next-auth/next";
 import { authOptions } from "@/pages/api/auth/[...nextauth]";
@@ -22,8 +22,7 @@ import { getDiscordMagnitude } from "@/utils/discord";
 
 const MIN_DISCORD_MAGNITUDE = 1;
 
-// Setup redis and slack clients
-const client = new Redis(process.env.REDIS_URL as string);
+// Setup slack client
 const slack = new WebClient(process.env.SLACK_ACCESS_TOKEN);
 const slackChannel = process.env.SLACK_CHANNEL ?? "";
 

--- a/community-frontend/pages/api/claim/status.ts
+++ b/community-frontend/pages/api/claim/status.ts
@@ -1,10 +1,7 @@
-import Redis from "ioredis";
+import { redis as client } from "@/utils/redis";
 import { getSession } from "next-auth/react";
 import type { NextApiRequest, NextApiResponse } from "next";
 import { mainNetwork } from "@/utils/networks";
-
-// Setup redis client
-const client = new Redis(process.env.REDIS_URL as string);
 
 /**
  * Checks if a user has claimed from faucet on a specific network in last 24h

--- a/community-frontend/utils/redis.test.ts
+++ b/community-frontend/utils/redis.test.ts
@@ -1,0 +1,30 @@
+import { test, expect } from "bun:test";
+
+process.env.REDIS_URL = "redis://127.0.0.1:1";
+
+// Black-holed connection: accepts TCP, never replies. This is what a dead
+// network looks like to ioredis — connect succeeds at the TCP layer (or
+// hangs), commands never get a response. With default ioredis options a
+// command issued here hangs forever, pinning its API request in memory.
+test(
+  "redis commands reject quickly against a black-holed connection",
+  async () => {
+    const blackhole = Bun.listen({
+      hostname: "127.0.0.1",
+      port: 0,
+      socket: { data() {}, open() {} },
+    });
+
+    const { createRedisClient } = await import("./redis");
+    const client = createRedisClient(`redis://127.0.0.1:${blackhole.port}`);
+
+    const started = Date.now();
+    expect(client.get("any-key")).rejects.toThrow();
+    await client.get("any-key").catch(() => {});
+    expect(Date.now() - started).toBeLessThan(8_000);
+
+    client.disconnect();
+    blackhole.stop(true);
+  },
+  { timeout: 15_000 },
+);

--- a/community-frontend/utils/redis.ts
+++ b/community-frontend/utils/redis.ts
@@ -1,0 +1,19 @@
+import Redis, { RedisOptions } from "ioredis";
+
+// Fail fast when redis is unreachable. ioredis defaults have no command
+// timeout and an unbounded offline queue, so a black-holed connection
+// (packets dropped, not refused) holds every in-flight API request in
+// memory indefinitely. Bounded timeouts turn a redis outage into fast
+// 500s instead of unbounded memory growth.
+export const redisOptions: RedisOptions = {
+  connectTimeout: 3_000,
+  commandTimeout: 3_000,
+  maxRetriesPerRequest: 2,
+  enableOfflineQueue: false,
+};
+
+export function createRedisClient(url: string): Redis {
+  return new Redis(url, redisOptions);
+}
+
+export const redis = createRedisClient(process.env.REDIS_URL as string);

--- a/frontend/pages/api/claim/new.ts
+++ b/frontend/pages/api/claim/new.ts
@@ -1,4 +1,4 @@
-import Redis from "ioredis";
+import { redis as client } from "@/utils/redis";
 import { WebClient } from "@slack/web-api";
 import { getServerSession } from "next-auth/next";
 import { authOptions } from "@/pages/api/auth/[...nextauth]";
@@ -23,8 +23,7 @@ import { whitelist, developerList } from "@/utils/whitelist";
 const MIN_GITHUB_FOLLOWERS = 10;
 // const MIN_DISCORD_MAGNITUDE = 5;
 
-// Setup redis and slack clients
-const client = new Redis(process.env.REDIS_URL as string);
+// Setup slack client
 const slack = new WebClient(process.env.SLACK_ACCESS_TOKEN);
 const slackChannel = process.env.SLACK_CHANNEL ?? "";
 

--- a/frontend/pages/api/claim/status.ts
+++ b/frontend/pages/api/claim/status.ts
@@ -1,10 +1,7 @@
-import Redis from "ioredis";
+import { redis as client } from "@/utils/redis";
 import { getSession } from "next-auth/react";
 import type { NextApiRequest, NextApiResponse } from "next";
 import { mainNetwork } from "@/utils/networks";
-
-// Setup redis client
-const client = new Redis(process.env.REDIS_URL as string);
 
 /**
  * Checks if a user has claimed from faucet on a specific network in last 24h

--- a/frontend/utils/redis.test.ts
+++ b/frontend/utils/redis.test.ts
@@ -1,0 +1,30 @@
+import { test, expect } from "bun:test";
+
+process.env.REDIS_URL = "redis://127.0.0.1:1";
+
+// Black-holed connection: accepts TCP, never replies. This is what a dead
+// network looks like to ioredis — connect succeeds at the TCP layer (or
+// hangs), commands never get a response. With default ioredis options a
+// command issued here hangs forever, pinning its API request in memory.
+test(
+  "redis commands reject quickly against a black-holed connection",
+  async () => {
+    const blackhole = Bun.listen({
+      hostname: "127.0.0.1",
+      port: 0,
+      socket: { data() {}, open() {} },
+    });
+
+    const { createRedisClient } = await import("./redis");
+    const client = createRedisClient(`redis://127.0.0.1:${blackhole.port}`);
+
+    const started = Date.now();
+    expect(client.get("any-key")).rejects.toThrow();
+    await client.get("any-key").catch(() => {});
+    expect(Date.now() - started).toBeLessThan(8_000);
+
+    client.disconnect();
+    blackhole.stop(true);
+  },
+  { timeout: 15_000 },
+);

--- a/frontend/utils/redis.ts
+++ b/frontend/utils/redis.ts
@@ -1,0 +1,19 @@
+import Redis, { RedisOptions } from "ioredis";
+
+// Fail fast when redis is unreachable. ioredis defaults have no command
+// timeout and an unbounded offline queue, so a black-holed connection
+// (packets dropped, not refused) holds every in-flight API request in
+// memory indefinitely. Bounded timeouts turn a redis outage into fast
+// 500s instead of unbounded memory growth.
+export const redisOptions: RedisOptions = {
+  connectTimeout: 3_000,
+  commandTimeout: 3_000,
+  maxRetriesPerRequest: 2,
+  enableOfflineQueue: false,
+};
+
+export function createRedisClient(url: string): Redis {
+  return new Redis(url, redisOptions);
+}
+
+export const redis = createRedisClient(process.env.REDIS_URL as string);


### PR DESCRIPTION
## Summary

Root-cause fix for the Aug 15–18 faucet OOM outage (symptom mitigation: #32). Gives ioredis bounded failure behavior — `commandTimeout`/`connectTimeout` of 3s, `maxRetriesPerRequest: 2`, offline queue disabled — via a shared `utils/redis.ts` in both apps, replacing the per-route `new Redis(url)` clients that used ioredis defaults.

## Root cause (diagnosed by reproduction, not by reading code)

ioredis defaults have **no command timeout** and an **unbounded offline queue**. When a redis connection is *black-holed* (packets dropped — a dead network, not a refused connection), every API request that touches redis awaits forever. Next.js never aborts the handler, so each request context is pinned in memory permanently.

Measured on a local production build with a black-holed redis: **~29 KB per hung request, monotonic, zero recovery** — 130 MB → 276 MB for 5,000 requests, still held after traffic stopped.

That is exactly what happened in production:

1. The node processes had been running since the Jul 23 boot with the pre-#27 config — pointing at the **remote** redis instance.
2. On **Aug 14 ~10:30 UTC** the VM's guest networking degraded (journal: metadata server unreachable). The remote redis became a black hole.
3. From that moment, all faucet traffic (claim attempts, claim-status polls) converted into permanently-held request contexts. Extrapolating 2.7 GB of growth at 29 KB/request ≈ 95k requests over ~18h ≈ 88 req/min — ordinary public-faucet traffic.
4. **Aug 15 04:51** the kernel OOM-killed the 2.9 GB node process; systemd failed the whole `supervisor.service` cgroup, orphaning node children; each supervisor restart duplicated the fleet (6 leftover node processes by Aug 17, unit memory peak 7.3 GB/7.8 GB) until the box died entirely.

Notably there is **no slow leak**: a production build held flat (140 MB) for 95 minutes idle and plateaued under 5k-request hammering of every path (unauth, authed drips, RPC refused, RPC black-holed, redis refused). Only the *hanging-redis* scenario reproduces the failure.

## The fix, verified

With this change, the same experiment — an **established** redis connection frozen mid-life (TCP proxy that stops forwarding), then 3,000 hammered requests — produces fast 500s (first failure in 3.007s, the command timeout) with RSS bounded and fully recovering (128 MB final). The unfixed build climbs monotonically and never recovers.

Behavior change to be aware of: with the offline queue disabled, a request that races a (re)connect gets an immediate 500 instead of waiting — e.g. the first request after a cold start. For a faucet this is the right trade: a redis outage now degrades to fast errors instead of eating the box.

## Regression test

`utils/redis.test.ts` (both apps): starts a TCP black-hole, asserts a command through `createRedisClient` rejects within 8s. Against ioredis defaults the same command is still hanging at 15s (verified during diagnosis).

## Testing

- `bun test utils/redis.test.ts` green in both apps
- `next build` (type-check) green in both apps
- Full-system verification as described above (production build, forged session, freeze-proxy)
