### PR TITLE
docs: faucet drips sUSDC, not ETH

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Seismic Faucet
 
-Seismic Faucet drips ETH across Seismic testnet networks.
+Seismic Faucet drips sUSDC across Seismic testnet networks.
 
 READMEs can be found individual subdirectories:
 


### PR DESCRIPTION
The README said the faucet drips ETH; it drips sUSDC (the faucet contract's `drip`/`dripDeveloper`/`dripWhitelist` all transfer sUSDC). One-line copy fix.