### PR TITLE
Add faucet CI checks

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,93 @@
+name: CI
+
+on:
+  pull_request:
+  push:
+    branches:
+      - seismic
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: faucet-ci-${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  frontend:
+    name: ${{ matrix.app }}
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    strategy:
+      fail-fast: false
+      matrix:
+        app:
+          - frontend
+          - community-frontend
+    defaults:
+      run:
+        working-directory: ${{ matrix.app }}
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v4
+
+      - name: Install Bun
+        uses: oven-sh/setup-bun@v2
+        with:
+          bun-version: 1.2.20
+
+      - name: Install dependencies
+        run: bun install --frozen-lockfile
+
+      - name: Typecheck
+        run: bun run typecheck
+
+      - name: Build
+        run: bun run build
+
+  contracts:
+    name: Contracts
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v4
+        with:
+          submodules: recursive
+
+      - name: Install Bun
+        uses: oven-sh/setup-bun@v2
+        with:
+          bun-version: 1.2.20
+
+      - name: Install Seismic Foundry
+        shell: bash
+        run: |
+          mkdir -p "$HOME/.seismic/bin" "$HOME/.config/.seismic/bin"
+          curl --proto '=https' --tlsv1.2 -fsSL \
+            https://raw.githubusercontent.com/SeismicSystems/seismic-foundry/5048ad8a85892a5abd6eec138a1c40543bbed33a/foundryup/foundryup \
+            -o "$HOME/.seismic/bin/sfoundryup"
+          chmod +x "$HOME/.seismic/bin/sfoundryup"
+          echo "$HOME/.seismic/bin" >> "$GITHUB_PATH"
+          echo "$HOME/.config/.seismic/bin" >> "$GITHUB_PATH"
+          "$HOME/.seismic/bin/sfoundryup" --install v0.3.0
+
+      - name: Install Solidity dependencies
+        working-directory: contracts
+        run: sforge soldeer install --config-location foundry
+
+      - name: Check formatting
+        working-directory: contracts
+        run: sforge fmt --check
+
+      - name: Build contracts
+        working-directory: contracts
+        run: sforge build
+
+      - name: Check contract ABIs
+        run: bun run scripts/check-contract-abi.ts
+
+      - name: Test contracts
+        working-directory: contracts
+        run: sforge test

--- a/community-frontend/bun.lock
+++ b/community-frontend/bun.lock
@@ -18,6 +18,7 @@
         "viem": "^2.40.2",
       },
       "devDependencies": {
+        "@types/bun": "^1.4.0",
         "@types/ioredis": "^5.0.0",
         "@types/node": "^22.10.2",
         "@types/react": "^18.3.18",
@@ -152,6 +153,8 @@
 
     "@tybys/wasm-util": ["@tybys/wasm-util@0.10.1", "", { "dependencies": { "tslib": "^2.4.0" } }, "sha512-9tTaPJLSiejZKx+Bmog4uSubteqTvFrVrURwkmHixBo0G4seD0zUxp98E1DzUBJxLQ3NPwXrGKDiVjwx/DpPsg=="],
 
+    "@types/bun": ["@types/bun@1.4.0", "", { "dependencies": { "bun-types": "1.4.0" } }, "sha512-K+lZULY23vRgK/CfTjFIV+tyifaNdSMlPh9j+6mQ/cLfpOznLyAuzgV/JQysyECpkBQLVMSyvjlr2fBUSA9wFQ=="],
+
     "@types/ioredis": ["@types/ioredis@5.0.0", "", { "dependencies": { "ioredis": "*" } }, "sha512-zJbJ3FVE17CNl5KXzdeSPtdltc4tMT3TzC6fxQS0sQngkbFZ6h+0uTafsRqu+eSLIugf6Yb0Ea0SUuRr42Nk9g=="],
 
     "@types/json5": ["@types/json5@0.0.29", "", {}, "sha512-dRLjCWHYg4oaA77cxO64oO+7JwCwnIzkZPdrrC71jQmQtlhM556pwKo5bUzqvZndkVbeFLIIi+9TC40JNF5hNQ=="],
@@ -277,6 +280,8 @@
     "brace-expansion": ["brace-expansion@1.1.12", "", { "dependencies": { "balanced-match": "^1.0.0", "concat-map": "0.0.1" } }, "sha512-9T9UjW3r0UW5c1Q7GTwllptXwhvYmEzFhzMfZ9H7FQWt+uZePjZPjBP/W1ZEyZ1twGWom5/56TF4lPcqjnDHcg=="],
 
     "braces": ["braces@3.0.3", "", { "dependencies": { "fill-range": "^7.1.1" } }, "sha512-yQbXgO/OSZVD2IsiLlro+7Hf6Q18EJrKSEsdoMzKePKXct3gvD8oLcOQdIzGupr5Fj+EDe8gO/lxc1BzfMpxvA=="],
+
+    "bun-types": ["bun-types@1.4.0", "", { "dependencies": { "@types/node": "*" } }, "sha512-iIKw23BspnQQYd3prITOBxeUsxBHnwzX6YJfGMuNOZzeNcMmVqzIIVGRm1l69ogaPQmb4wB6BN8mA5bE9YuC5Q=="],
 
     "busboy": ["busboy@1.6.0", "", { "dependencies": { "streamsearch": "^1.1.0" } }, "sha512-8SFQbg/0hQ9xy3UNTB0YEnsNBbWfhf7RtnzpL7TkBiTBRfrQ9Fxcnz7VJsleJpyp6rVLvXiuORqjlHi5q+PYuA=="],
 
@@ -884,6 +889,8 @@
 
     "@typescript-eslint/visitor-keys/eslint-visitor-keys": ["eslint-visitor-keys@4.2.1", "", {}, "sha512-Uhdk5sfqcee/9H/rCOJikYz67o0a2Tw2hGRPOG2Y1R2dg7brRe1uG0yaNQDHu+TO/uQPF/5eCapvYSmHUjt7JQ=="],
 
+    "bun-types/@types/node": ["@types/node@24.10.1", "", { "dependencies": { "undici-types": "~7.16.0" } }, "sha512-GNWcUTRBgIRJD5zj+Tq0fKOJ5XZajIiBroOF0yvj2bSU1WvNdYS/dn9UxwsujGW4JX06dnHyjV2y9rRaybH0iQ=="],
+
     "eslint-import-resolver-node/debug": ["debug@3.2.7", "", { "dependencies": { "ms": "^2.1.1" } }, "sha512-CFjzYYAi4ThfiQvizrFQevTTXHtnCqWfe7x1AhgEscTz6ZbLbfoLRLPugTQyBth6f8ZERVUSyWHFD/7Wu4t1XQ=="],
 
     "eslint-module-utils/debug": ["debug@3.2.7", "", { "dependencies": { "ms": "^2.1.1" } }, "sha512-CFjzYYAi4ThfiQvizrFQevTTXHtnCqWfe7x1AhgEscTz6ZbLbfoLRLPugTQyBth6f8ZERVUSyWHFD/7Wu4t1XQ=="],
@@ -925,6 +932,8 @@
     "@slack/web-api/@types/node/undici-types": ["undici-types@7.16.0", "", {}, "sha512-Zz+aZWSj8LE6zoxD+xrjh4VfkIG8Ya6LvYkZqtUQGJPZjYl53ypCaUwWqo7eI0x66KBGeRo+mlBEkMSeSZ38Nw=="],
 
     "@typescript-eslint/typescript-estree/minimatch/brace-expansion": ["brace-expansion@2.0.2", "", { "dependencies": { "balanced-match": "^1.0.0" } }, "sha512-Jt0vHyM+jmUBqojB7E1NIYadt0vI0Qxjxd2TErW94wDz+E2LAm5vKMXXwg6ZZBTHPuUlDgQHKXvjGBdfcF1ZDQ=="],
+
+    "bun-types/@types/node/undici-types": ["undici-types@7.16.0", "", {}, "sha512-Zz+aZWSj8LE6zoxD+xrjh4VfkIG8Ya6LvYkZqtUQGJPZjYl53ypCaUwWqo7eI0x66KBGeRo+mlBEkMSeSZ38Nw=="],
 
     "glob/minimatch/brace-expansion": ["brace-expansion@2.0.2", "", { "dependencies": { "balanced-match": "^1.0.0" } }, "sha512-Jt0vHyM+jmUBqojB7E1NIYadt0vI0Qxjxd2TErW94wDz+E2LAm5vKMXXwg6ZZBTHPuUlDgQHKXvjGBdfcF1ZDQ=="],
 

--- a/community-frontend/package.json
+++ b/community-frontend/package.json
@@ -7,6 +7,7 @@
   "scripts": {
     "dev": "bun run next dev -p 3001",
     "build": "bun run next build",
+    "typecheck": "tsc --noEmit",
     "start": "bun run next start -p 3001",
     "lint": "bun run next lint",
     "contracts:compile": "bun run --cwd ../contracts sforge build",
@@ -31,6 +32,7 @@
     "axios": "1.13.2"
   },
   "devDependencies": {
+    "@types/bun": "^1.4.0",
     "@types/ioredis": "^5.0.0",
     "@types/node": "^22.10.2",
     "@types/react": "^18.3.18",

--- a/frontend/bun.lock
+++ b/frontend/bun.lock
@@ -18,6 +18,7 @@
         "viem": "^2.40.2",
       },
       "devDependencies": {
+        "@types/bun": "^1.4.0",
         "@types/ioredis": "^5.0.0",
         "@types/node": "^22.10.2",
         "@types/react": "^18.3.18",
@@ -152,6 +153,8 @@
 
     "@tybys/wasm-util": ["@tybys/wasm-util@0.10.1", "", { "dependencies": { "tslib": "^2.4.0" } }, "sha512-9tTaPJLSiejZKx+Bmog4uSubteqTvFrVrURwkmHixBo0G4seD0zUxp98E1DzUBJxLQ3NPwXrGKDiVjwx/DpPsg=="],
 
+    "@types/bun": ["@types/bun@1.4.0", "", { "dependencies": { "bun-types": "1.4.0" } }, "sha512-K+lZULY23vRgK/CfTjFIV+tyifaNdSMlPh9j+6mQ/cLfpOznLyAuzgV/JQysyECpkBQLVMSyvjlr2fBUSA9wFQ=="],
+
     "@types/ioredis": ["@types/ioredis@5.0.0", "", { "dependencies": { "ioredis": "*" } }, "sha512-zJbJ3FVE17CNl5KXzdeSPtdltc4tMT3TzC6fxQS0sQngkbFZ6h+0uTafsRqu+eSLIugf6Yb0Ea0SUuRr42Nk9g=="],
 
     "@types/json5": ["@types/json5@0.0.29", "", {}, "sha512-dRLjCWHYg4oaA77cxO64oO+7JwCwnIzkZPdrrC71jQmQtlhM556pwKo5bUzqvZndkVbeFLIIi+9TC40JNF5hNQ=="],
@@ -277,6 +280,8 @@
     "brace-expansion": ["brace-expansion@1.1.12", "", { "dependencies": { "balanced-match": "^1.0.0", "concat-map": "0.0.1" } }, "sha512-9T9UjW3r0UW5c1Q7GTwllptXwhvYmEzFhzMfZ9H7FQWt+uZePjZPjBP/W1ZEyZ1twGWom5/56TF4lPcqjnDHcg=="],
 
     "braces": ["braces@3.0.3", "", { "dependencies": { "fill-range": "^7.1.1" } }, "sha512-yQbXgO/OSZVD2IsiLlro+7Hf6Q18EJrKSEsdoMzKePKXct3gvD8oLcOQdIzGupr5Fj+EDe8gO/lxc1BzfMpxvA=="],
+
+    "bun-types": ["bun-types@1.4.0", "", { "dependencies": { "@types/node": "*" } }, "sha512-iIKw23BspnQQYd3prITOBxeUsxBHnwzX6YJfGMuNOZzeNcMmVqzIIVGRm1l69ogaPQmb4wB6BN8mA5bE9YuC5Q=="],
 
     "busboy": ["busboy@1.6.0", "", { "dependencies": { "streamsearch": "^1.1.0" } }, "sha512-8SFQbg/0hQ9xy3UNTB0YEnsNBbWfhf7RtnzpL7TkBiTBRfrQ9Fxcnz7VJsleJpyp6rVLvXiuORqjlHi5q+PYuA=="],
 
@@ -884,6 +889,8 @@
 
     "@typescript-eslint/visitor-keys/eslint-visitor-keys": ["eslint-visitor-keys@4.2.1", "", {}, "sha512-Uhdk5sfqcee/9H/rCOJikYz67o0a2Tw2hGRPOG2Y1R2dg7brRe1uG0yaNQDHu+TO/uQPF/5eCapvYSmHUjt7JQ=="],
 
+    "bun-types/@types/node": ["@types/node@24.10.1", "", { "dependencies": { "undici-types": "~7.16.0" } }, "sha512-GNWcUTRBgIRJD5zj+Tq0fKOJ5XZajIiBroOF0yvj2bSU1WvNdYS/dn9UxwsujGW4JX06dnHyjV2y9rRaybH0iQ=="],
+
     "eslint-import-resolver-node/debug": ["debug@3.2.7", "", { "dependencies": { "ms": "^2.1.1" } }, "sha512-CFjzYYAi4ThfiQvizrFQevTTXHtnCqWfe7x1AhgEscTz6ZbLbfoLRLPugTQyBth6f8ZERVUSyWHFD/7Wu4t1XQ=="],
 
     "eslint-module-utils/debug": ["debug@3.2.7", "", { "dependencies": { "ms": "^2.1.1" } }, "sha512-CFjzYYAi4ThfiQvizrFQevTTXHtnCqWfe7x1AhgEscTz6ZbLbfoLRLPugTQyBth6f8ZERVUSyWHFD/7Wu4t1XQ=="],
@@ -925,6 +932,8 @@
     "@slack/web-api/@types/node/undici-types": ["undici-types@7.16.0", "", {}, "sha512-Zz+aZWSj8LE6zoxD+xrjh4VfkIG8Ya6LvYkZqtUQGJPZjYl53ypCaUwWqo7eI0x66KBGeRo+mlBEkMSeSZ38Nw=="],
 
     "@typescript-eslint/typescript-estree/minimatch/brace-expansion": ["brace-expansion@2.0.2", "", { "dependencies": { "balanced-match": "^1.0.0" } }, "sha512-Jt0vHyM+jmUBqojB7E1NIYadt0vI0Qxjxd2TErW94wDz+E2LAm5vKMXXwg6ZZBTHPuUlDgQHKXvjGBdfcF1ZDQ=="],
+
+    "bun-types/@types/node/undici-types": ["undici-types@7.16.0", "", {}, "sha512-Zz+aZWSj8LE6zoxD+xrjh4VfkIG8Ya6LvYkZqtUQGJPZjYl53ypCaUwWqo7eI0x66KBGeRo+mlBEkMSeSZ38Nw=="],
 
     "glob/minimatch/brace-expansion": ["brace-expansion@2.0.2", "", { "dependencies": { "balanced-match": "^1.0.0" } }, "sha512-Jt0vHyM+jmUBqojB7E1NIYadt0vI0Qxjxd2TErW94wDz+E2LAm5vKMXXwg6ZZBTHPuUlDgQHKXvjGBdfcF1ZDQ=="],
 

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -7,6 +7,7 @@
   "scripts": {
     "dev": "bun run next dev",
     "build": "bun run next build",
+    "typecheck": "tsc --noEmit",
     "start": "bun run next start",
     "lint": "bun run next lint",
     "contracts:compile": "bun run --cwd ../contracts sforge build",
@@ -31,6 +32,7 @@
     "axios": "1.13.2"
   },
   "devDependencies": {
+    "@types/bun": "^1.4.0",
     "@types/ioredis": "^5.0.0",
     "@types/node": "^22.10.2",
     "@types/react": "^18.3.18",

--- a/scripts/check-contract-abi.ts
+++ b/scripts/check-contract-abi.ts
@@ -1,0 +1,73 @@
+import { seismicFaucetAbi as communityAbi } from "../community-frontend/utils/contract";
+import { seismicFaucetAbi as frontendAbi } from "../frontend/utils/contract";
+
+const artifactPath = new URL(
+  "../contracts/out/SeismicFaucet.sol/SeismicFaucet.json",
+  import.meta.url,
+);
+const artifactDisplayPath =
+  "contracts/out/SeismicFaucet.sol/SeismicFaucet.json";
+
+type AbiItem = Record<string, unknown> & { type?: string };
+
+function canonicalize(value: unknown): unknown {
+  if (Array.isArray(value)) {
+    return value.map(canonicalize);
+  }
+  if (value && typeof value === "object") {
+    return Object.fromEntries(
+      Object.entries(value as Record<string, unknown>)
+        .sort(([left], [right]) => left.localeCompare(right))
+        .map(([key, child]) => [key, canonicalize(child)]),
+    );
+  }
+  return value;
+}
+
+function normalizedAbi(abi: readonly AbiItem[]): string[] {
+  return abi
+    .filter((item) => item.type !== "constructor")
+    .map((item) => JSON.stringify(canonicalize(item)))
+    .sort();
+}
+
+function assertCurrentAbi(
+  name: string,
+  actual: readonly AbiItem[],
+  expected: readonly AbiItem[],
+): void {
+  const normalizedActual = normalizedAbi(actual);
+  const normalizedExpected = normalizedAbi(expected);
+  if (JSON.stringify(normalizedActual) === JSON.stringify(normalizedExpected)) {
+    return;
+  }
+
+  const actualItems = new Set(normalizedActual);
+  const expectedItems = new Set(normalizedExpected);
+  const missing = normalizedExpected.filter((item) => !actualItems.has(item));
+  const stale = normalizedActual.filter((item) => !expectedItems.has(item));
+  console.error(`${name} ABI does not match ${artifactDisplayPath}`);
+  if (missing.length > 0) {
+    console.error("Missing ABI entries:", missing.join("\n"));
+  }
+  if (stale.length > 0) {
+    console.error("Stale ABI entries:", stale.join("\n"));
+  }
+  process.exitCode = 1;
+}
+
+const artifactFile = Bun.file(artifactPath);
+if (!(await artifactFile.exists())) {
+  throw new Error(
+    `Missing contract artifact ${artifactDisplayPath}; run sforge build first`,
+  );
+}
+const artifact = await artifactFile.json();
+if (!artifact || !Array.isArray(artifact.abi)) {
+  throw new Error(
+    `Missing contract ABI in ${artifactDisplayPath}; run sforge build first`,
+  );
+}
+
+assertCurrentAbi("frontend", frontendAbi, artifact.abi);
+assertCurrentAbi("community-frontend", communityAbi, artifact.abi);


### PR DESCRIPTION
## Summary

- run frozen installs, typechecks, and production builds for both faucet frontends
- run Seismic Foundry formatting, build, and contract tests
- structurally compare both checked-in frontend ABIs with a freshly built SeismicFaucet artifact
- limit push CI to `seismic` while retaining pull-request and manual runs

## Test plan

- both frozen Bun installs, typechecks, and production builds
- `sforge soldeer install --config-location foundry`
- `sforge fmt --check`
- `sforge build`
- `bun run scripts/check-contract-abi.ts`
- `sforge test` (27 tests)
- workflow YAML parse

Fixes SEI-411 — https://linear.app/seismic-systems/issue/SEI-411/3-faucet-ci-validate-frontends-contracts-and-abi