### PR TITLE
Add Rust workspace CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,6 +15,54 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
+  rust:
+    name: Rust
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v4
+
+      - name: Detect Rust workspace
+        id: workspace
+        shell: bash
+        run: |
+          if [[ -f Cargo.toml ]]; then
+            echo "exists=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "exists=false" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Install Rust
+        if: steps.workspace.outputs.exists == 'true'
+        uses: dtolnay/rust-toolchain@1.88.0
+        with:
+          components: rustfmt, clippy
+
+      - name: Cache Rust build
+        if: steps.workspace.outputs.exists == 'true'
+        uses: Swatinem/rust-cache@v2
+
+      - name: Install Redis
+        if: steps.workspace.outputs.exists == 'true'
+        run: sudo apt-get update && sudo apt-get install --yes redis-server
+
+      - name: Check formatting
+        if: steps.workspace.outputs.exists == 'true'
+        run: cargo fmt --all -- --check
+
+      - name: Lint
+        if: steps.workspace.outputs.exists == 'true'
+        run: cargo clippy --workspace --all-targets --locked -- -D warnings
+
+      - name: Test
+        if: steps.workspace.outputs.exists == 'true'
+        run: cargo test --workspace --locked
+
+      - name: Build production binaries
+        if: steps.workspace.outputs.exists == 'true'
+        run: cargo build --workspace --release --locked
+
   frontend:
     name: ${{ matrix.app }}
     runs-on: ubuntu-latest


### PR DESCRIPTION
## Summary

- add a Rust 1.88 CI lane that activates when the repository contains a Cargo workspace
- enforce formatting, Clippy with warnings denied, locked workspace tests, and locked release builds
- keep the check independently mergeable before the machine-funding server lands

## Test plan

- workflow YAML parse
- no-workspace detection on current `seismic`
- Rust 1.88 format, Clippy, 19 tests, and release build against the machine-funding branch

Fixes SEI-412 — https://linear.app/seismic-systems/issue/SEI-412/3-faucet-ci-validate-the-rust-workspace