### PR TITLE
Add bounded machine funding contract role

### DIFF
--- a/community-frontend/package.json
+++ b/community-frontend/package.json
@@ -12,7 +12,7 @@
     "lint": "bun run next lint",
     "contracts:compile": "bun run --cwd ../contracts sforge build",
     "contracts:test": "bun run --cwd ../contracts sforge test",
-    "contracts:deploy": "source .env && RPC_URL=$RPC_URL FAUCET_PRIVATE_KEY=$FAUCET_PRIVATE_KEY FAUCET_RESERVE_PRIVATE_KEY=$FAUCET_RESERVE_PRIVATE_KEY SUSDC_ADDRESS=$SUSDC_ADDRESS bun run --cwd ../contracts sforge script script/Deploy.s.sol --rpc-url $RPC_URL --broadcast --private-key $FAUCET_PRIVATE_KEY --unsafe-private-storage"
+    "contracts:deploy": "source .env && RPC_URL=$RPC_URL FAUCET_PRIVATE_KEY=$FAUCET_PRIVATE_KEY FAUCET_RESERVE_PRIVATE_KEY=$FAUCET_RESERVE_PRIVATE_KEY INTERNAL_FUNDING_ADDRESS=$INTERNAL_FUNDING_ADDRESS SUSDC_ADDRESS=$SUSDC_ADDRESS bun run --cwd ../contracts sforge script script/Deploy.s.sol --rpc-url $RPC_URL --broadcast --private-key $FAUCET_PRIVATE_KEY --unsafe-private-storage"
   },
   "dependencies": {
     "@slack/web-api": "^7.10.0",

--- a/community-frontend/utils/contract.ts
+++ b/community-frontend/utils/contract.ts
@@ -15,6 +15,19 @@ export const seismicFaucetAbi = [
   },
   {
     type: "event",
+    name: "FaucetTransferred",
+    inputs: [
+      {
+        name: "recipient",
+        type: "address",
+        indexed: true,
+        internalType: "address",
+      },
+    ],
+    anonymous: false,
+  },
+  {
+    type: "event",
     name: "FaucetDrained",
     inputs: [
       {
@@ -29,6 +42,25 @@ export const seismicFaucetAbi = [
   {
     type: "event",
     name: "OperatorUpdated",
+    inputs: [
+      {
+        name: "operator",
+        type: "address",
+        indexed: true,
+        internalType: "address",
+      },
+      {
+        name: "status",
+        type: "bool",
+        indexed: false,
+        internalType: "bool",
+      },
+    ],
+    anonymous: false,
+  },
+  {
+    type: "event",
+    name: "MachineOperatorUpdated",
     inputs: [
       {
         name: "operator",
@@ -88,6 +120,13 @@ export const seismicFaucetAbi = [
   },
   {
     type: "function",
+    name: "MAX_EXACT_TRANSFER_AMOUNT",
+    stateMutability: "view",
+    inputs: [],
+    outputs: [{ name: "", type: "uint256", internalType: "uint256" }],
+  },
+  {
+    type: "function",
     name: "susdc",
     stateMutability: "view",
     inputs: [],
@@ -96,6 +135,13 @@ export const seismicFaucetAbi = [
   {
     type: "function",
     name: "approvedOperators",
+    stateMutability: "view",
+    inputs: [{ name: "", type: "address", internalType: "address" }],
+    outputs: [{ name: "", type: "bool", internalType: "bool" }],
+  },
+  {
+    type: "function",
+    name: "machineOperators",
     stateMutability: "view",
     inputs: [{ name: "", type: "address", internalType: "address" }],
     outputs: [{ name: "", type: "bool", internalType: "bool" }],
@@ -149,6 +195,24 @@ export const seismicFaucetAbi = [
   },
   {
     type: "function",
+    name: "transferExact",
+    stateMutability: "nonpayable",
+    inputs: [
+      {
+        name: "_recipient",
+        type: "address",
+        internalType: "address",
+      },
+      {
+        name: "_amount",
+        type: "uint256",
+        internalType: "uint256",
+      },
+    ],
+    outputs: [],
+  },
+  {
+    type: "function",
     name: "drain",
     stateMutability: "nonpayable",
     inputs: [
@@ -163,6 +227,24 @@ export const seismicFaucetAbi = [
   {
     type: "function",
     name: "updateApprovedOperator",
+    stateMutability: "nonpayable",
+    inputs: [
+      {
+        name: "_operator",
+        type: "address",
+        internalType: "address",
+      },
+      {
+        name: "_status",
+        type: "bool",
+        internalType: "bool",
+      },
+    ],
+    outputs: [],
+  },
+  {
+    type: "function",
+    name: "updateMachineOperator",
     stateMutability: "nonpayable",
     inputs: [
       {
@@ -225,6 +307,19 @@ export const seismicFaucetAbi = [
   {
     type: "function",
     name: "updateWhitelistDripAmount",
+    stateMutability: "nonpayable",
+    inputs: [
+      {
+        name: "_amount",
+        type: "uint256",
+        internalType: "uint256",
+      },
+    ],
+    outputs: [],
+  },
+  {
+    type: "function",
+    name: "updateMaxExactTransferAmount",
     stateMutability: "nonpayable",
     inputs: [
       {

--- a/contracts/script/Deploy.s.sol
+++ b/contracts/script/Deploy.s.sol
@@ -21,18 +21,22 @@ contract DeployScript is Script {
         // Reserve account
         uint256 reservePrivateKey = vm.envUint("FAUCET_RESERVE_PRIVATE_KEY");
 
+        // Dedicated machine funding operator
+        address machineFundingAccount = vm.envAddress("INTERNAL_FUNDING_ADDRESS");
+        require(machineFundingAccount != address(0), "Invalid machine funding account");
+
         // SUSDC (SRC20) token address
         address susdcAddress = vm.envAddress("SUSDC_ADDRESS");
 
         address reserveAccount = vm.addr(reservePrivateKey);
         address faucetAccount = vm.addr(faucetPrivateKey);
-
         vm.startBroadcast(faucetPrivateKey);
 
         SeismicFaucet faucet = new SeismicFaucet(susdcAddress);
 
         faucet.updateSuperOperator(reserveAccount, true);
         faucet.updateApprovedOperator(faucetAccount, true);
+        faucet.updateMachineOperator(machineFundingAccount, true);
 
         // Seed the faucet with SUSDC by admin-minting directly into it (no self-transfer round-trip)
         ISUSDCMintable(susdcAddress).mint(address(faucet), suint256(INITIAL_FAUCET_SEED));
@@ -49,5 +53,6 @@ contract DeployScript is Script {
         console.log("Initial seed (SUSDC, 6d):", INITIAL_FAUCET_SEED);
         console.log("Deployer/Faucet (super + approved operator):", faucetAccount);
         console.log("Reserve account (super operator):", reserveAccount);
+        console.log("Machine funding account (exact-transfer operator):", machineFundingAccount);
     }
 }

--- a/contracts/src/SeismicFaucet.sol
+++ b/contracts/src/SeismicFaucet.sol
@@ -21,8 +21,12 @@ contract SeismicFaucet {
     uint256 public DEVELOPER_USDC_AMOUNT = 50e6; // 50 SUSDC
     /// @notice SUSDC to disperse to whitelisted users
     uint256 public WHITELIST_USDC_AMOUNT = 250e6; // 250 SUSDC
+    /// @notice Maximum SUSDC allowed in one exact operator transfer
+    uint256 public MAX_EXACT_TRANSFER_AMOUNT = 250e6; // 250 SUSDC
     /// @notice Addresses of approved operators
     mapping(address => bool) public approvedOperators;
+    /// @notice Addresses allowed to submit exact machine transfers
+    mapping(address => bool) public machineOperators;
     /// @notice Addresses of super operators
     mapping(address => bool) public superOperators;
 
@@ -41,11 +45,21 @@ contract SeismicFaucet {
         _;
     }
 
+    /// @notice Requires sender to be a machine or super operator
+    modifier isMachineOperator() {
+        require(machineOperators[msg.sender] || superOperators[msg.sender], "Not machine operator");
+        _;
+    }
+
     /// ============ Events ============
 
     /// @notice Emitted after faucet drips to a recipient
     /// @param recipient address dripped to
     event FaucetDripped(address indexed recipient);
+
+    /// @notice Emitted after an exact operator transfer
+    /// @param recipient address transferred to
+    event FaucetTransferred(address indexed recipient);
 
     /// @notice Emitted after faucet drained to a recipient
     /// @param recipient address drained to
@@ -55,6 +69,11 @@ contract SeismicFaucet {
     /// @param operator address being updated
     /// @param status new operator status
     event OperatorUpdated(address indexed operator, bool status);
+
+    /// @notice Emitted after machine operator status is updated
+    /// @param operator address being updated
+    /// @param status new operator status
+    event MachineOperatorUpdated(address indexed operator, bool status);
 
     /// @notice Emitted after super operator is updated
     /// @param operator address being updated
@@ -99,6 +118,17 @@ contract SeismicFaucet {
         emit FaucetDripped(_recipient);
     }
 
+    /// @notice Transfers an exact SUSDC amount to a recipient
+    /// @param _recipient recipient address
+    /// @param _amount SUSDC amount in 6-decimal base units
+    function transferExact(address _recipient, uint256 _amount) external isMachineOperator {
+        require(_recipient != address(0), "Invalid recipient");
+        require(_amount > 0 && _amount <= MAX_EXACT_TRANSFER_AMOUNT, "Invalid transfer amount");
+        require(susdc.transfer(_recipient, suint256(_amount)), "Failed transferring SUSDC");
+
+        emit FaucetTransferred(_recipient);
+    }
+
     /// @notice Allows super operator to drain contract of SUSDC
     /// @param _recipient to send drained SUSDC to
     /// @dev `susdc.balance()` on SRC20 returns `balances[msg.sender]`, i.e. this contract's own balance
@@ -116,6 +146,14 @@ contract SeismicFaucet {
     function updateApprovedOperator(address _operator, bool _status) external isSuperOperator {
         approvedOperators[_operator] = _status;
         emit OperatorUpdated(_operator, _status);
+    }
+
+    /// @notice Allows super operator to update exact-transfer operator status
+    /// @param _operator address to update
+    /// @param _status whether the operator may submit exact transfers
+    function updateMachineOperator(address _operator, bool _status) external isSuperOperator {
+        machineOperators[_operator] = _status;
+        emit MachineOperatorUpdated(_operator, _status);
     }
 
     /// @notice Allows super operator to update super operator
@@ -142,5 +180,12 @@ contract SeismicFaucet {
     /// @param _amount SUSDC to drip to whitelisted users (6 decimals)
     function updateWhitelistDripAmount(uint256 _amount) external isSuperOperator {
         WHITELIST_USDC_AMOUNT = _amount;
+    }
+
+    /// @notice Allows super operator to update the exact transfer ceiling
+    /// @param _amount maximum SUSDC per transfer in 6-decimal base units
+    function updateMaxExactTransferAmount(uint256 _amount) external isSuperOperator {
+        require(_amount > 0, "Invalid transfer amount");
+        MAX_EXACT_TRANSFER_AMOUNT = _amount;
     }
 }

--- a/contracts/src/test/SeismicFaucet.t.sol
+++ b/contracts/src/test/SeismicFaucet.t.sol
@@ -10,6 +10,9 @@ import "./utils/SeismicFaucetTest.sol"; // SeismicFaucet ds-test
 library Errors {
     string constant NotSuperOperator = "Not super operator";
     string constant NotApprovedOperator = "Not approved operator";
+    string constant NotMachineOperator = "Not machine operator";
+    string constant InvalidRecipient = "Invalid recipient";
+    string constant InvalidTransferAmount = "Invalid transfer amount";
 }
 
 /// @notice Default SUSDC drip amounts for tests (6 decimals)
@@ -243,5 +246,62 @@ contract Tests is SeismicFaucetTest {
     /// @notice Default whitelist SUSDC amount is 250 SUSDC
     function testDefaultWhitelistAmount() public {
         assertEq(FAUCET.WHITELIST_USDC_AMOUNT(), Amounts.WHITELIST);
+    }
+
+    /// @notice Machine operators can transfer an exact bounded amount
+    function testMachineOperatorCanTransferExactAmount() public {
+        uint256 amount = 37_500_001;
+        uint256 aliceBefore = ALICE.SUSDCBalance();
+
+        FAUCET.updateMachineOperator(address(BOB), true);
+        BOB.transferExact(address(ALICE), amount);
+
+        assertEq(ALICE.SUSDCBalance(), aliceBefore + amount);
+    }
+
+    /// @notice Public drip operators cannot transfer exact amounts
+    function testApprovedOperatorCannotTransferExactAmount() public {
+        FAUCET.updateApprovedOperator(address(BOB), true);
+        assertErrorFunctionWithAddressAndUint256(
+            BOB.transferExact, address(ALICE), Amounts.REGULAR, Errors.NotMachineOperator
+        );
+    }
+
+    /// @notice Exact transfers cannot exceed the configured ceiling
+    function testCannotTransferExactAmountAboveMaximum() public {
+        FAUCET.updateMachineOperator(address(BOB), true);
+
+        assertErrorFunctionWithAddressAndUint256(
+            BOB.transferExact, address(ALICE), Amounts.WHITELIST + 1, Errors.InvalidTransferAmount
+        );
+    }
+
+    /// @notice Exact transfers reject zero amounts and the zero recipient
+    function testExactTransferValidatesRecipientAndAmount() public {
+        FAUCET.updateMachineOperator(address(BOB), true);
+
+        assertErrorFunctionWithAddressAndUint256(BOB.transferExact, address(ALICE), 0, Errors.InvalidTransferAmount);
+        assertErrorFunctionWithAddressAndUint256(
+            BOB.transferExact, address(0), Amounts.REGULAR, Errors.InvalidRecipient
+        );
+    }
+
+    /// @notice Super operators can change the exact transfer ceiling
+    function testSuperOperatorCanUpdateMaximumExactTransferAmount() public {
+        uint256 newMaximum = 1_000e6;
+
+        ALICE.updateMaxExactTransferAmount(newMaximum);
+
+        assertEq(FAUCET.MAX_EXACT_TRANSFER_AMOUNT(), newMaximum);
+    }
+
+    /// @notice Non-super operators cannot change the exact transfer ceiling
+    function testCannotUpdateMaximumExactTransferAmountIfNotSuperOperator() public {
+        assertErrorFunctionWithUint256(BOB.updateMaxExactTransferAmount, 1_000e6, Errors.NotSuperOperator);
+    }
+
+    /// @notice Non-super operators cannot grant the machine operator role
+    function testCannotUpdateMachineOperatorIfNotSuperOperator() public {
+        assertErrorFunctionWithAddressAndBool(BOB.updateMachineOperator, address(BOB), true, Errors.NotSuperOperator);
     }
 }

--- a/contracts/src/test/utils/DSTestExtended.sol
+++ b/contracts/src/test/utils/DSTestExtended.sol
@@ -47,6 +47,24 @@ contract DSTestExtended is DSTest {
 
     /// @notice Calls function and checks for matching revert message
     /// @param erroringFunction to call
+    /// @param _addr address to pass to function
+    /// @param _amount uint256 to pass to function
+    /// @param message to check against revert error string
+    function assertErrorFunctionWithAddressAndUint256(
+        function(address, uint256) external erroringFunction,
+        address _addr,
+        uint256 _amount,
+        string memory message
+    ) internal {
+        try erroringFunction(_addr, _amount) {
+            fail();
+        } catch Error(string memory error) {
+            assertEq(error, message);
+        }
+    }
+
+    /// @notice Calls function and checks for matching revert message
+    /// @param erroringFunction to call
     /// @param param uint256 to pass to function
     /// @param message to check against revert error string
     function assertErrorFunctionWithUint256(

--- a/contracts/src/test/utils/SeismicFaucetUser.sol
+++ b/contracts/src/test/utils/SeismicFaucetUser.sol
@@ -52,6 +52,13 @@ contract SeismicFaucetUser {
         FAUCET.dripWhitelist(_recipient);
     }
 
+    /// @notice Transfers an exact SUSDC amount from the faucet
+    /// @param _recipient recipient address
+    /// @param _amount SUSDC amount in 6-decimal base units
+    function transferExact(address _recipient, uint256 _amount) public {
+        FAUCET.transferExact(_recipient, _amount);
+    }
+
     /// @notice Drains faucet to a recipient address
     /// @param _recipient to drain to
     function drain(address _recipient) public {
@@ -63,6 +70,13 @@ contract SeismicFaucetUser {
     /// @param _status to update for operator (true == allowed to drip)
     function updateApprovedOperator(address _operator, bool _status) public {
         FAUCET.updateApprovedOperator(_operator, _status);
+    }
+
+    /// @notice Adds or removes an exact-transfer operator
+    /// @param _operator address
+    /// @param _status whether the operator may submit exact transfers
+    function updateMachineOperator(address _operator, bool _status) public {
+        FAUCET.updateMachineOperator(_operator, _status);
     }
 
     /// @notice Updates super operator
@@ -88,5 +102,11 @@ contract SeismicFaucetUser {
     /// @param _amount SUSDC to drip to whitelisted users (6 decimals)
     function updateWhitelistDripAmount(uint256 _amount) public {
         FAUCET.updateWhitelistDripAmount(_amount);
+    }
+
+    /// @notice Updates the exact transfer ceiling
+    /// @param _amount maximum SUSDC per transfer in 6-decimal base units
+    function updateMaxExactTransferAmount(uint256 _amount) public {
+        FAUCET.updateMaxExactTransferAmount(_amount);
     }
 }

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -12,7 +12,7 @@
     "lint": "bun run next lint",
     "contracts:compile": "bun run --cwd ../contracts sforge build",
     "contracts:test": "bun run --cwd ../contracts sforge test",
-    "contracts:deploy": "source .env && RPC_URL=$RPC_URL FAUCET_PRIVATE_KEY=$FAUCET_PRIVATE_KEY FAUCET_RESERVE_PRIVATE_KEY=$FAUCET_RESERVE_PRIVATE_KEY SUSDC_ADDRESS=$SUSDC_ADDRESS bun run --cwd ../contracts sforge script script/Deploy.s.sol --rpc-url $RPC_URL --broadcast --private-key $FAUCET_PRIVATE_KEY --unsafe-private-storage"
+    "contracts:deploy": "source .env && RPC_URL=$RPC_URL FAUCET_PRIVATE_KEY=$FAUCET_PRIVATE_KEY FAUCET_RESERVE_PRIVATE_KEY=$FAUCET_RESERVE_PRIVATE_KEY INTERNAL_FUNDING_ADDRESS=$INTERNAL_FUNDING_ADDRESS SUSDC_ADDRESS=$SUSDC_ADDRESS bun run --cwd ../contracts sforge script script/Deploy.s.sol --rpc-url $RPC_URL --broadcast --private-key $FAUCET_PRIVATE_KEY --unsafe-private-storage"
   },
   "dependencies": {
     "@slack/web-api": "^7.10.0",

--- a/frontend/utils/contract.ts
+++ b/frontend/utils/contract.ts
@@ -15,6 +15,19 @@ export const seismicFaucetAbi = [
   },
   {
     type: "event",
+    name: "FaucetTransferred",
+    inputs: [
+      {
+        name: "recipient",
+        type: "address",
+        indexed: true,
+        internalType: "address",
+      },
+    ],
+    anonymous: false,
+  },
+  {
+    type: "event",
     name: "FaucetDrained",
     inputs: [
       {
@@ -29,6 +42,25 @@ export const seismicFaucetAbi = [
   {
     type: "event",
     name: "OperatorUpdated",
+    inputs: [
+      {
+        name: "operator",
+        type: "address",
+        indexed: true,
+        internalType: "address",
+      },
+      {
+        name: "status",
+        type: "bool",
+        indexed: false,
+        internalType: "bool",
+      },
+    ],
+    anonymous: false,
+  },
+  {
+    type: "event",
+    name: "MachineOperatorUpdated",
     inputs: [
       {
         name: "operator",
@@ -88,6 +120,13 @@ export const seismicFaucetAbi = [
   },
   {
     type: "function",
+    name: "MAX_EXACT_TRANSFER_AMOUNT",
+    stateMutability: "view",
+    inputs: [],
+    outputs: [{ name: "", type: "uint256", internalType: "uint256" }],
+  },
+  {
+    type: "function",
     name: "susdc",
     stateMutability: "view",
     inputs: [],
@@ -96,6 +135,13 @@ export const seismicFaucetAbi = [
   {
     type: "function",
     name: "approvedOperators",
+    stateMutability: "view",
+    inputs: [{ name: "", type: "address", internalType: "address" }],
+    outputs: [{ name: "", type: "bool", internalType: "bool" }],
+  },
+  {
+    type: "function",
+    name: "machineOperators",
     stateMutability: "view",
     inputs: [{ name: "", type: "address", internalType: "address" }],
     outputs: [{ name: "", type: "bool", internalType: "bool" }],
@@ -149,6 +195,24 @@ export const seismicFaucetAbi = [
   },
   {
     type: "function",
+    name: "transferExact",
+    stateMutability: "nonpayable",
+    inputs: [
+      {
+        name: "_recipient",
+        type: "address",
+        internalType: "address",
+      },
+      {
+        name: "_amount",
+        type: "uint256",
+        internalType: "uint256",
+      },
+    ],
+    outputs: [],
+  },
+  {
+    type: "function",
     name: "drain",
     stateMutability: "nonpayable",
     inputs: [
@@ -163,6 +227,24 @@ export const seismicFaucetAbi = [
   {
     type: "function",
     name: "updateApprovedOperator",
+    stateMutability: "nonpayable",
+    inputs: [
+      {
+        name: "_operator",
+        type: "address",
+        internalType: "address",
+      },
+      {
+        name: "_status",
+        type: "bool",
+        internalType: "bool",
+      },
+    ],
+    outputs: [],
+  },
+  {
+    type: "function",
+    name: "updateMachineOperator",
     stateMutability: "nonpayable",
     inputs: [
       {
@@ -225,6 +307,19 @@ export const seismicFaucetAbi = [
   {
     type: "function",
     name: "updateWhitelistDripAmount",
+    stateMutability: "nonpayable",
+    inputs: [
+      {
+        name: "_amount",
+        type: "uint256",
+        internalType: "uint256",
+      },
+    ],
+    outputs: [],
+  },
+  {
+    type: "function",
+    name: "updateMaxExactTransferAmount",
     stateMutability: "nonpayable",
     inputs: [
       {


### PR DESCRIPTION
## Summary

- add a dedicated machine-operator role for exact sUSDC transfers
- cap each exact transfer and keep machine operators separate from super operators
- grant the configured operator during deployment and synchronize both frontend ABIs

## Test plan

- `sforge fmt --check`
- `sforge build`
- `sforge test`
- `bun run scripts/check-contract-abi.ts`
- frontend and community-frontend typechecks and production builds

## Stack

1 of 4. Split from #35. Merge this PR first; next is #38.

Fixes SEI-414 — https://linear.app/seismic-systems/issue/SEI-414/3-machine-funding-add-a-bounded-contract-operator-role