### PR TITLE
Add the authenticated machine funding server

### DIFF
--- a/machine-funding-server/src/chain.rs
+++ b/machine-funding-server/src/chain.rs
@@ -1,0 +1,459 @@
+use crate::{
+    config::Config,
+    model::{ChainResult, FundingAsset, FundingInput, PreparedTransaction, ServiceError},
+};
+use alloy_eips::eip2718::Encodable2718;
+use alloy_network::TransactionBuilder;
+use alloy_primitives::{keccak256, Address, Bytes, TxKind, B256, U256};
+use alloy_provider::Provider;
+use alloy_rpc_types_eth::{TransactionInput, TransactionRequest};
+use alloy_signer_local::PrivateKeySigner;
+use alloy_sol_types::{sol, SolCall};
+use async_trait::async_trait;
+use seismic_alloy_network::{wallet::SeismicWallet, SeismicReth};
+use seismic_alloy_provider::{SeismicProviderBuilder, SeismicUnsignedProvider};
+use seismic_alloy_rpc_types::{SeismicTransactionReceipt, SeismicTransactionRequest};
+use std::{str::FromStr, time::Duration};
+use tokio::time::{sleep, timeout};
+use url::Url;
+
+const LEGACY_TRANSACTION_TYPE: u8 = 0;
+const TRANSACTION_GAS_LIMIT: u64 = 500_000;
+const GAS_PRICE_MULTIPLIER: u128 = 2;
+const RECEIPT_POLL_INTERVAL: Duration = Duration::from_millis(500);
+const RPC_REQUEST_TIMEOUT: Duration = Duration::from_secs(5);
+const TERMINAL_BROADCAST_ERRORS: &[&str] = &[
+    "insufficient funds",
+    "intrinsic gas too low",
+    "invalid sender",
+    "invalid chain id",
+    "transaction type not supported",
+];
+
+sol! {
+    #[sol(rpc)]
+    interface SeismicFaucet {
+        function transferExact(address _recipient, uint256 _amount) external;
+        function machineOperators(address operator) external view returns (bool);
+        function superOperators(address operator) external view returns (bool);
+        function MAX_EXACT_TRANSFER_AMOUNT() external view returns (uint256);
+    }
+}
+
+#[async_trait]
+pub trait ChainDriver: Clone + Send + Sync + 'static {
+    fn operator_key(&self) -> &str;
+    async fn pending_nonce(&self) -> Result<u64, ServiceError>;
+    async fn prepare(
+        &self,
+        input: &FundingInput,
+        nonce: u64,
+    ) -> Result<PreparedTransaction, ServiceError>;
+    async fn broadcast_and_confirm(
+        &self,
+        transaction: &PreparedTransaction,
+    ) -> Result<ChainResult, ServiceError>;
+    async fn health(&self) -> Result<(), ServiceError>;
+}
+
+#[derive(Clone)]
+pub struct EvmChainDriver {
+    provider: SeismicUnsignedProvider<SeismicReth>,
+    wallet: SeismicWallet<SeismicReth>,
+    operator_address: Address,
+    faucet_address: Address,
+    chain_id: u64,
+    operator_key: String,
+    confirmations: u64,
+    receipt_timeout: Duration,
+}
+
+impl EvmChainDriver {
+    pub async fn connect(config: &Config) -> Result<Self, ServiceError> {
+        let rpc_url = Url::parse(&config.rpc_url).map_err(chain_error)?;
+        let provider = SeismicProviderBuilder::new().connect_http(rpc_url);
+        let chain_id = rpc_timeout(provider.get_chain_id()).await?;
+        if chain_id != config.chain_id {
+            return Err(chain_error(format!(
+                "RPC chain id {chain_id} does not match configured chain id {}",
+                config.chain_id
+            )));
+        }
+        let signer = PrivateKeySigner::from_str(&config.private_key).map_err(chain_error)?;
+        let operator_address = signer.address();
+        if operator_address != config.funding_address {
+            return Err(chain_error(
+                "INTERNAL_FUNDING_PRIVATE_KEY does not match INTERNAL_FUNDING_ADDRESS",
+            ));
+        }
+        let operator_key = format!("{chain_id}:{operator_address:#x}");
+        let driver = Self {
+            provider,
+            wallet: SeismicWallet::from(signer),
+            operator_address,
+            faucet_address: config.faucet_address,
+            chain_id,
+            operator_key,
+            confirmations: config.confirmations,
+            receipt_timeout: config.receipt_timeout,
+        };
+        driver.validate_faucet(config.max_susdc_amount).await?;
+        Ok(driver)
+    }
+
+    fn transfer_exact_data(input: &FundingInput) -> Bytes {
+        SeismicFaucet::transferExactCall {
+            _recipient: input.recipient,
+            _amount: input.amount,
+        }
+        .abi_encode()
+        .into()
+    }
+
+    fn transaction_request(
+        &self,
+        input: &FundingInput,
+        nonce: u64,
+        gas_price: u128,
+    ) -> SeismicTransactionRequest {
+        let (to, value, calldata) = match input.asset {
+            FundingAsset::Susdc => (
+                self.faucet_address,
+                U256::ZERO,
+                Self::transfer_exact_data(input),
+            ),
+            FundingAsset::Native => (input.recipient, input.amount, Bytes::new()),
+        };
+        SeismicTransactionRequest {
+            inner: TransactionRequest {
+                from: Some(self.operator_address),
+                to: Some(TxKind::Call(to)),
+                gas_price: Some(gas_price),
+                gas: Some(TRANSACTION_GAS_LIMIT),
+                value: Some(value),
+                input: TransactionInput::from(calldata),
+                nonce: Some(nonce),
+                chain_id: Some(self.chain_id),
+                transaction_type: Some(LEGACY_TRANSACTION_TYPE),
+                ..Default::default()
+            },
+            seismic_elements: None,
+        }
+    }
+
+    async fn receipt_result(&self, hash: B256) -> Result<ChainResult, ServiceError> {
+        match timeout(self.receipt_timeout, async {
+            loop {
+                let receipt = rpc_timeout(self.provider.get_transaction_receipt(hash)).await?;
+                match receipt_status(receipt.as_ref()) {
+                    Some(ChainResult::Reverted) => return Ok(ChainResult::Reverted),
+                    Some(ChainResult::Success) => {
+                        let receipt_block = receipt
+                            .as_ref()
+                            .and_then(|confirmed| confirmed.block_number)
+                            .expect("receipt_status requires a block number");
+                        let latest_block = rpc_timeout(self.provider.get_block_number()).await?;
+                        let required_block =
+                            receipt_block.saturating_add(self.confirmations.saturating_sub(1));
+                        if latest_block >= required_block {
+                            return Ok(ChainResult::Success);
+                        }
+                    }
+                    _ => {}
+                }
+                sleep(RECEIPT_POLL_INTERVAL).await;
+            }
+        })
+        .await
+        {
+            Ok(result) => result,
+            Err(_) => Ok(ChainResult::Pending),
+        }
+    }
+
+    async fn validate_faucet(&self, configured_max: U256) -> Result<(), ServiceError> {
+        let code =
+            rpc_timeout(async { self.provider.get_code_at(self.faucet_address).await }).await?;
+        if code.is_empty() {
+            return Err(chain_error("FAUCET_ADDRESS has no deployed bytecode"));
+        }
+        let faucet = SeismicFaucet::new(self.faucet_address, &self.provider);
+        let machine_operator =
+            rpc_timeout(async { faucet.machineOperators(self.operator_address).call().await })
+                .await?;
+        if !machine_operator {
+            return Err(chain_error(
+                "internal funding signer is not a machine operator",
+            ));
+        }
+        let super_operator =
+            rpc_timeout(async { faucet.superOperators(self.operator_address).call().await })
+                .await?;
+        if super_operator {
+            return Err(chain_error(
+                "internal funding signer must not be a super operator",
+            ));
+        }
+        let on_chain_max =
+            rpc_timeout(async { faucet.MAX_EXACT_TRANSFER_AMOUNT().call().await }).await?;
+        if configured_max > on_chain_max {
+            return Err(chain_error(format!(
+                "configured SUSDC maximum {configured_max} exceeds contract maximum {on_chain_max}"
+            )));
+        }
+        Ok(())
+    }
+
+    async fn sign_transaction(
+        &self,
+        input: &FundingInput,
+        nonce: u64,
+        gas_price: u128,
+    ) -> Result<PreparedTransaction, ServiceError> {
+        let request = self.transaction_request(input, nonce, gas_price);
+        let envelope = TransactionBuilder::<SeismicReth>::build(request, &self.wallet)
+            .await
+            .map_err(chain_error)?;
+        let serialized = envelope.encoded_2718();
+        let hash = keccak256(&serialized);
+        Ok(PreparedTransaction {
+            hash: format!("{hash:#x}"),
+            nonce,
+            serialized_transaction: format!("0x{}", hex::encode(serialized)),
+        })
+    }
+}
+
+#[async_trait]
+impl ChainDriver for EvmChainDriver {
+    fn operator_key(&self) -> &str {
+        &self.operator_key
+    }
+
+    async fn pending_nonce(&self) -> Result<u64, ServiceError> {
+        rpc_timeout(async {
+            self.provider
+                .get_transaction_count(self.operator_address)
+                .pending()
+                .await
+        })
+        .await
+    }
+
+    async fn prepare(
+        &self,
+        input: &FundingInput,
+        nonce: u64,
+    ) -> Result<PreparedTransaction, ServiceError> {
+        let quoted_gas_price = rpc_timeout(self.provider.get_gas_price()).await?;
+        let gas_price = quoted_gas_price
+            .checked_mul(GAS_PRICE_MULTIPLIER)
+            .ok_or_else(|| chain_error("RPC gas price overflow"))?;
+        self.sign_transaction(input, nonce, gas_price).await
+    }
+
+    async fn broadcast_and_confirm(
+        &self,
+        transaction: &PreparedTransaction,
+    ) -> Result<ChainResult, ServiceError> {
+        let raw = hex::decode(transaction.serialized_transaction.trim_start_matches("0x"))
+            .map_err(chain_error)?;
+        let expected_hash = B256::from_str(&transaction.hash).map_err(chain_error)?;
+        match timeout(
+            RPC_REQUEST_TIMEOUT,
+            self.provider.send_raw_transaction(&raw),
+        )
+        .await
+        {
+            Ok(Ok(pending)) if *pending.tx_hash() != expected_hash => {
+                return Ok(ChainResult::Rejected(
+                    "RPC returned a different transaction hash".into(),
+                ));
+            }
+            Ok(Ok(_)) => {}
+            Ok(Err(error)) => {
+                let message = error.to_string();
+                if let Some(result) = classify_broadcast_error(&message) {
+                    return Ok(result);
+                }
+                tracing::warn!(%message, hash = %transaction.hash, "raw transaction broadcast was not acknowledged");
+            }
+            Err(_) => {
+                tracing::warn!(hash = %transaction.hash, "raw transaction broadcast timed out");
+            }
+        }
+        self.receipt_result(expected_hash).await
+    }
+
+    async fn health(&self) -> Result<(), ServiceError> {
+        rpc_timeout(self.provider.get_chain_id()).await.map(|_| ())
+    }
+}
+
+fn classify_broadcast_error(message: &str) -> Option<ChainResult> {
+    let lower = message.to_ascii_lowercase();
+    TERMINAL_BROADCAST_ERRORS
+        .iter()
+        .any(|candidate| lower.contains(candidate))
+        .then(|| ChainResult::Rejected(message.to_owned()))
+}
+
+fn receipt_status(receipt: Option<&SeismicTransactionReceipt>) -> Option<ChainResult> {
+    let receipt = receipt?;
+    receipt.block_number?;
+    receipt.block_hash?;
+    if receipt.inner.status() {
+        Some(ChainResult::Success)
+    } else {
+        Some(ChainResult::Reverted)
+    }
+}
+
+async fn rpc_timeout<T, E>(
+    future: impl std::future::Future<Output = Result<T, E>>,
+) -> Result<T, ServiceError>
+where
+    E: std::fmt::Display,
+{
+    timeout(RPC_REQUEST_TIMEOUT, future)
+        .await
+        .map_err(|_| chain_error("RPC request timed out"))?
+        .map_err(chain_error)
+}
+
+fn chain_error(error: impl std::fmt::Display) -> ServiceError {
+    tracing::error!(%error, "machine funding chain operation failed");
+    ServiceError::new(
+        502,
+        "transaction_failed",
+        "Unable to submit funding transaction",
+    )
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::model::FundingInput;
+    use alloy_sol_types::SolCall;
+
+    const TRANSFER_EXACT_SELECTOR: [u8; 4] = [0xe1, 0x72, 0xa7, 0xc3];
+
+    fn driver() -> EvmChainDriver {
+        let signer = PrivateKeySigner::from_str(&format!("0x{}", "1".repeat(64))).unwrap();
+        let operator_address = signer.address();
+        EvmChainDriver {
+            provider: SeismicProviderBuilder::new()
+                .connect_http(Url::parse("http://127.0.0.1:1").unwrap()),
+            wallet: SeismicWallet::from(signer),
+            operator_address,
+            faucet_address: Address::with_last_byte(1),
+            operator_key: format!("5124:{operator_address:#x}"),
+            chain_id: 5124,
+            confirmations: 1,
+            receipt_timeout: Duration::from_millis(10),
+        }
+    }
+
+    fn input() -> FundingInput {
+        FundingInput {
+            asset: FundingAsset::Susdc,
+            idempotency_key: "order-123".into(),
+            recipient: Address::with_last_byte(0xa1),
+            recipient_text: "0x00000000000000000000000000000000000000A1".into(),
+            amount: U256::from(12_500_000u64),
+            reason: "order_payout".into(),
+        }
+    }
+
+    fn receipt(status: u8, block_number: Option<u64>) -> SeismicTransactionReceipt {
+        let block_number = block_number
+            .map(|number| format!("\"0x{number:x}\""))
+            .unwrap_or_else(|| "null".into());
+        let bloom = "0".repeat(512);
+        serde_json::from_str(&format!(
+            r#"{{
+                "blockHash":"0x{block_hash}",
+                "blockNumber":{block_number},
+                "contractAddress":null,
+                "cumulativeGasUsed":"0x5208",
+                "effectiveGasPrice":"0x1",
+                "from":"0x0000000000000000000000000000000000000001",
+                "gasUsed":"0x5208",
+                "logs":[],
+                "logsBloom":"0x{bloom}",
+                "status":"0x{status:x}",
+                "to":"0x0000000000000000000000000000000000000002",
+                "transactionHash":"0x{transaction_hash}",
+                "transactionIndex":"0x0",
+                "type":"0x0"
+            }}"#,
+            block_hash = "1".repeat(64),
+            transaction_hash = "2".repeat(64),
+        ))
+        .unwrap()
+    }
+
+    #[tokio::test]
+    async fn signs_legacy_transaction_and_hashes_exact_bytes() {
+        let driver = driver();
+        let prepared = driver
+            .sign_transaction(&input(), 7, 2_000_000_000u128)
+            .await
+            .unwrap();
+        let raw = hex::decode(prepared.serialized_transaction.trim_start_matches("0x")).unwrap();
+        assert_eq!(prepared.hash, format!("{:#x}", keccak256(&raw)));
+        assert_eq!(prepared.nonce, 7);
+        assert!(raw.first().is_some_and(|prefix| *prefix >= 0xc0));
+
+        let calldata = EvmChainDriver::transfer_exact_data(&input());
+        assert_eq!(&calldata[..4], &TRANSFER_EXACT_SELECTOR);
+        let decoded = SeismicFaucet::transferExactCall::abi_decode(&calldata).unwrap();
+        assert_eq!(decoded._recipient, input().recipient);
+        assert_eq!(decoded._amount, input().amount);
+        assert_eq!(calldata.len(), 68);
+    }
+
+    #[test]
+    fn native_gas_request_is_transparent_legacy_value_transfer() {
+        let driver = driver();
+        let mut native = input();
+        native.asset = FundingAsset::Native;
+        native.amount = U256::from(10_000_000_000_000_000u64);
+        let request = driver.transaction_request(&native, 9, 2_000_000_000);
+
+        assert_eq!(
+            request.inner.transaction_type,
+            Some(LEGACY_TRANSACTION_TYPE)
+        );
+        assert_eq!(request.inner.to, Some(TxKind::Call(native.recipient)));
+        assert_eq!(request.inner.value, Some(native.amount));
+        assert_eq!(request.inner.input.input(), Some(&Bytes::new()));
+        assert!(request.seismic_elements.is_none());
+    }
+
+    #[test]
+    fn classifies_terminal_send_errors_without_erasing_provider_text() {
+        assert_eq!(
+            classify_broadcast_error("insufficient funds for gas"),
+            Some(ChainResult::Rejected("insufficient funds for gas".into()))
+        );
+        assert_eq!(classify_broadcast_error("connection reset"), None);
+    }
+
+    #[test]
+    fn alloy_receipts_keep_ambiguous_and_terminal_states_distinct() {
+        let successful = receipt(1, Some(12));
+        let reverted = receipt(0, Some(12));
+        let unmined = receipt(1, None);
+        let mut incomplete = receipt(1, Some(12));
+        incomplete.block_hash = None;
+        assert_eq!(receipt_status(None), None);
+        assert_eq!(receipt_status(Some(&unmined)), None);
+        assert_eq!(receipt_status(Some(&incomplete)), None);
+        assert_eq!(receipt_status(Some(&reverted)), Some(ChainResult::Reverted));
+        assert_eq!(
+            receipt_status(Some(&successful)),
+            Some(ChainResult::Success)
+        );
+    }
+}

--- a/machine-funding-server/src/config.rs
+++ b/machine-funding-server/src/config.rs
@@ -1,0 +1,253 @@
+use alloy_primitives::{Address, U256};
+use std::{env, net::SocketAddr, str::FromStr, time::Duration};
+use thiserror::Error;
+
+const DEFAULT_BIND_ADDR: &str = "127.0.0.1:3002";
+const DEFAULT_RATE_LIMIT: u64 = 10;
+const DEFAULT_RATE_WINDOW_SECONDS: u64 = 3_600;
+const DEFAULT_CONFIRMATIONS: u64 = 1;
+const DEFAULT_RECEIPT_TIMEOUT_MS: u64 = 20_000;
+const DEFAULT_LOCK_WAIT_MS: u64 = 5_000;
+pub const DEFAULT_REQUEST_TIMEOUT_MS: u64 = 45_000;
+pub const MAX_REQUEST_TIMEOUT_MS: u64 = 45_000;
+const MINIMUM_TOKEN_LENGTH: usize = 32;
+const MAX_REDIS_INTEGER: u64 = i64::MAX as u64;
+
+#[derive(Clone)]
+pub struct Config {
+    pub bind_addr: SocketAddr,
+    pub redis_url: String,
+    pub rpc_url: String,
+    pub chain_id: u64,
+    pub token: String,
+    pub private_key: String,
+    pub funding_address: Address,
+    pub faucet_address: Address,
+    pub max_susdc_amount: U256,
+    pub gas_amount_wei: U256,
+    pub global_susdc_budget: U256,
+    pub global_gas_budget_wei: U256,
+    pub rate_limit: u64,
+    pub rate_window: Duration,
+    pub confirmations: u64,
+    pub receipt_timeout: Duration,
+    pub lock_wait: Duration,
+    pub request_timeout: Duration,
+}
+
+#[derive(Debug, Error)]
+pub enum ConfigError {
+    #[error("{0} is required")]
+    Missing(&'static str),
+    #[error("{0} is invalid")]
+    Invalid(&'static str),
+    #[error("{0} must be at least {1} characters")]
+    TooShort(&'static str, usize),
+    #[error("single-transfer amount exceeds its global budget")]
+    BudgetBelowTransfer,
+}
+
+impl Config {
+    pub fn from_env() -> Result<Self, ConfigError> {
+        Self::from_lookup(|name| env::var(name).ok())
+    }
+
+    pub fn from_lookup(lookup: impl Fn(&str) -> Option<String>) -> Result<Self, ConfigError> {
+        let required = |name: &'static str| lookup(name).ok_or(ConfigError::Missing(name));
+        let token = required("INTERNAL_FUNDING_TOKEN")?;
+        if token.len() < MINIMUM_TOKEN_LENGTH {
+            return Err(ConfigError::TooShort(
+                "INTERNAL_FUNDING_TOKEN",
+                MINIMUM_TOKEN_LENGTH,
+            ));
+        }
+        let private_key = required("INTERNAL_FUNDING_PRIVATE_KEY")?;
+        validate_private_key(&private_key)?;
+
+        let max_susdc_amount = parse_u256(
+            required("INTERNAL_FUNDING_MAX_SUSDC_AMOUNT")?,
+            "INTERNAL_FUNDING_MAX_SUSDC_AMOUNT",
+        )?;
+        let gas_amount_wei = parse_u256(
+            required("INTERNAL_FUNDING_GAS_AMOUNT_WEI")?,
+            "INTERNAL_FUNDING_GAS_AMOUNT_WEI",
+        )?;
+        let global_susdc_budget = parse_u256(
+            required("INTERNAL_FUNDING_GLOBAL_SUSDC_BUDGET")?,
+            "INTERNAL_FUNDING_GLOBAL_SUSDC_BUDGET",
+        )?;
+        let global_gas_budget_wei = parse_u256(
+            required("INTERNAL_FUNDING_GLOBAL_GAS_BUDGET_WEI")?,
+            "INTERNAL_FUNDING_GLOBAL_GAS_BUDGET_WEI",
+        )?;
+        if max_susdc_amount > global_susdc_budget || gas_amount_wei > global_gas_budget_wei {
+            return Err(ConfigError::BudgetBelowTransfer);
+        }
+
+        let bind_addr: SocketAddr = lookup("INTERNAL_FUNDING_BIND_ADDR")
+            .unwrap_or_else(|| DEFAULT_BIND_ADDR.to_owned())
+            .parse()
+            .map_err(|_| ConfigError::Invalid("INTERNAL_FUNDING_BIND_ADDR"))?;
+        if !bind_addr.ip().is_loopback() {
+            return Err(ConfigError::Invalid("INTERNAL_FUNDING_BIND_ADDR"));
+        }
+        let request_timeout_ms = parse_u64(
+            lookup("INTERNAL_FUNDING_REQUEST_TIMEOUT_MS"),
+            DEFAULT_REQUEST_TIMEOUT_MS,
+            "INTERNAL_FUNDING_REQUEST_TIMEOUT_MS",
+        )?;
+        if request_timeout_ms > MAX_REQUEST_TIMEOUT_MS {
+            return Err(ConfigError::Invalid("INTERNAL_FUNDING_REQUEST_TIMEOUT_MS"));
+        }
+
+        Ok(Self {
+            bind_addr,
+            redis_url: required("REDIS_URL")?,
+            rpc_url: required("RPC_URL")?,
+            chain_id: required("INTERNAL_FUNDING_CHAIN_ID")?
+                .parse()
+                .map_err(|_| ConfigError::Invalid("INTERNAL_FUNDING_CHAIN_ID"))?,
+            token,
+            private_key,
+            funding_address: Address::from_str(&required("INTERNAL_FUNDING_ADDRESS")?)
+                .map_err(|_| ConfigError::Invalid("INTERNAL_FUNDING_ADDRESS"))?,
+            faucet_address: Address::from_str(&required("FAUCET_ADDRESS")?)
+                .map_err(|_| ConfigError::Invalid("FAUCET_ADDRESS"))?,
+            max_susdc_amount,
+            gas_amount_wei,
+            global_susdc_budget,
+            global_gas_budget_wei,
+            rate_limit: parse_u64(
+                lookup("INTERNAL_FUNDING_RATE_LIMIT"),
+                DEFAULT_RATE_LIMIT,
+                "INTERNAL_FUNDING_RATE_LIMIT",
+            )?,
+            rate_window: Duration::from_secs(parse_u64(
+                lookup("INTERNAL_FUNDING_RATE_WINDOW_SECONDS"),
+                DEFAULT_RATE_WINDOW_SECONDS,
+                "INTERNAL_FUNDING_RATE_WINDOW_SECONDS",
+            )?),
+            confirmations: parse_u64(
+                lookup("INTERNAL_FUNDING_CONFIRMATIONS"),
+                DEFAULT_CONFIRMATIONS,
+                "INTERNAL_FUNDING_CONFIRMATIONS",
+            )?,
+            receipt_timeout: Duration::from_millis(parse_u64(
+                lookup("INTERNAL_FUNDING_RECEIPT_TIMEOUT_MS"),
+                DEFAULT_RECEIPT_TIMEOUT_MS,
+                "INTERNAL_FUNDING_RECEIPT_TIMEOUT_MS",
+            )?),
+            lock_wait: Duration::from_millis(parse_u64(
+                lookup("INTERNAL_FUNDING_LOCK_WAIT_MS"),
+                DEFAULT_LOCK_WAIT_MS,
+                "INTERNAL_FUNDING_LOCK_WAIT_MS",
+            )?),
+            request_timeout: Duration::from_millis(request_timeout_ms),
+        })
+    }
+}
+
+fn validate_private_key(value: &str) -> Result<(), ConfigError> {
+    if value.len() != 66 || !value.starts_with("0x") || hex::decode(&value[2..]).is_err() {
+        return Err(ConfigError::Invalid("INTERNAL_FUNDING_PRIVATE_KEY"));
+    }
+    Ok(())
+}
+
+fn parse_u256(value: String, name: &'static str) -> Result<U256, ConfigError> {
+    let parsed = U256::from_str_radix(&value, 10).map_err(|_| ConfigError::Invalid(name))?;
+    if parsed == U256::ZERO || parsed > U256::from(MAX_REDIS_INTEGER) {
+        return Err(ConfigError::Invalid(name));
+    }
+    Ok(parsed)
+}
+
+fn parse_u64(value: Option<String>, default: u64, name: &'static str) -> Result<u64, ConfigError> {
+    let parsed = value
+        .map(|raw| raw.parse().map_err(|_| ConfigError::Invalid(name)))
+        .transpose()?
+        .unwrap_or(default);
+    if parsed == 0 {
+        return Err(ConfigError::Invalid(name));
+    }
+    Ok(parsed)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::collections::HashMap;
+
+    const _: () = assert!(DEFAULT_REQUEST_TIMEOUT_MS < 50_000);
+
+    fn valid_env() -> HashMap<&'static str, String> {
+        HashMap::from([
+            ("REDIS_URL", "redis://127.0.0.1/".into()),
+            ("RPC_URL", "http://127.0.0.1:8545".into()),
+            ("INTERNAL_FUNDING_CHAIN_ID", "5124".into()),
+            ("INTERNAL_FUNDING_TOKEN", "x".repeat(32)),
+            (
+                "INTERNAL_FUNDING_PRIVATE_KEY",
+                format!("0x{}", "1".repeat(64)),
+            ),
+            (
+                "INTERNAL_FUNDING_ADDRESS",
+                "0x19E7E376E7C213B7E7e7e46cc70A5dD086DAff2A".into(),
+            ),
+            (
+                "FAUCET_ADDRESS",
+                "0x0000000000000000000000000000000000000001".into(),
+            ),
+            ("INTERNAL_FUNDING_MAX_SUSDC_AMOUNT", "250000000".into()),
+            (
+                "INTERNAL_FUNDING_GAS_AMOUNT_WEI",
+                "10000000000000000".into(),
+            ),
+            ("INTERNAL_FUNDING_GLOBAL_SUSDC_BUDGET", "1000000000".into()),
+            (
+                "INTERNAL_FUNDING_GLOBAL_GAS_BUDGET_WEI",
+                "1000000000000000000".into(),
+            ),
+        ])
+    }
+
+    #[test]
+    fn loads_defaults_and_required_limits() {
+        let values = valid_env();
+        let config = Config::from_lookup(|key| values.get(key).cloned()).unwrap();
+        assert_eq!(config.bind_addr, "127.0.0.1:3002".parse().unwrap());
+        assert_eq!(config.rate_limit, 10);
+        assert_eq!(config.receipt_timeout, Duration::from_secs(20));
+        assert_eq!(config.request_timeout, Duration::from_secs(45));
+    }
+
+    #[test]
+    fn rejects_weak_token_and_oversized_transfer() {
+        let mut values = valid_env();
+        values.insert("INTERNAL_FUNDING_TOKEN", "short".into());
+        assert!(Config::from_lookup(|key| values.get(key).cloned()).is_err());
+        values.insert("INTERNAL_FUNDING_TOKEN", "x".repeat(32));
+        values.insert("INTERNAL_FUNDING_MAX_SUSDC_AMOUNT", "1000000001".into());
+        assert!(matches!(
+            Config::from_lookup(|key| values.get(key).cloned()),
+            Err(ConfigError::BudgetBelowTransfer)
+        ));
+    }
+
+    #[test]
+    fn rejects_non_loopback_bind_and_oversized_request_timeout() {
+        let mut values = valid_env();
+        values.insert("INTERNAL_FUNDING_BIND_ADDR", "0.0.0.0:3002".into());
+        assert!(matches!(
+            Config::from_lookup(|key| values.get(key).cloned()),
+            Err(ConfigError::Invalid("INTERNAL_FUNDING_BIND_ADDR"))
+        ));
+
+        values.insert("INTERNAL_FUNDING_BIND_ADDR", "[::1]:3002".into());
+        values.insert("INTERNAL_FUNDING_REQUEST_TIMEOUT_MS", "45001".into());
+        assert!(matches!(
+            Config::from_lookup(|key| values.get(key).cloned()),
+            Err(ConfigError::Invalid("INTERNAL_FUNDING_REQUEST_TIMEOUT_MS"))
+        ));
+    }
+}

--- a/machine-funding-server/src/http.rs
+++ b/machine-funding-server/src/http.rs
@@ -1,0 +1,273 @@
+use crate::{
+    chain::ChainDriver,
+    model::{
+        ErrorBody, ErrorEnvelope, FundingAsset, FundingInput, FundingResponse, GasRequest,
+        ServiceError, SusdcRequest,
+    },
+    service::FundingService,
+    store::FundingStore,
+};
+use alloy_primitives::{Address, U256};
+use axum::{
+    extract::{rejection::JsonRejection, State},
+    http::{header, HeaderMap, HeaderValue, StatusCode},
+    response::{IntoResponse, Response},
+    routing::{get, post},
+    Json, Router,
+};
+use regex::Regex;
+use serde::Serialize;
+use sha2::{Digest, Sha256};
+use std::{
+    str::FromStr,
+    sync::{Arc, OnceLock},
+};
+use subtle::ConstantTimeEq;
+
+const IDEMPOTENCY_PATTERN: &str = r"^[A-Za-z0-9._:-]{1,128}$";
+const REASON_PATTERN: &str = r"^[A-Za-z0-9._:-]{1,64}$";
+
+pub fn router<S, D>(service: FundingService<S, D>) -> Router
+where
+    S: FundingStore,
+    D: ChainDriver,
+{
+    Router::new()
+        .route("/api/internal/health", get(liveness))
+        .route("/api/internal/readiness", get(readiness::<S, D>))
+        .route("/api/internal/transfers", post(transfer::<S, D>))
+        .route("/api/internal/gas", post(gas::<S, D>))
+        .with_state(Arc::new(service))
+}
+
+async fn transfer<S, D>(
+    State(service): State<Arc<FundingService<S, D>>>,
+    headers: HeaderMap,
+    payload: Result<Json<SusdcRequest>, JsonRejection>,
+) -> Result<Json<FundingResponse>, ServiceError>
+where
+    S: FundingStore,
+    D: ChainDriver,
+{
+    authorize(&headers, &service.config().token)?;
+    let Json(request) = payload.map_err(invalid_json)?;
+    let common = validate_common(request.idempotency_key, request.recipient, request.reason)?;
+    let amount = parse_amount(&request.amount, service.config().max_susdc_amount)?;
+    service
+        .execute(FundingInput {
+            asset: FundingAsset::Susdc,
+            amount,
+            ..common
+        })
+        .await
+        .map(Json)
+}
+
+async fn gas<S, D>(
+    State(service): State<Arc<FundingService<S, D>>>,
+    headers: HeaderMap,
+    payload: Result<Json<GasRequest>, JsonRejection>,
+) -> Result<Json<FundingResponse>, ServiceError>
+where
+    S: FundingStore,
+    D: ChainDriver,
+{
+    authorize(&headers, &service.config().token)?;
+    let Json(request) = payload.map_err(invalid_json)?;
+    let common = validate_common(request.idempotency_key, request.recipient, request.reason)?;
+    service
+        .execute(FundingInput {
+            asset: FundingAsset::Native,
+            amount: service.config().gas_amount_wei,
+            ..common
+        })
+        .await
+        .map(Json)
+}
+
+async fn liveness() -> Json<Health> {
+    Json(Health { status: "ok" })
+}
+
+async fn readiness<S, D>(
+    State(service): State<Arc<FundingService<S, D>>>,
+    headers: HeaderMap,
+) -> Result<Json<Health>, ServiceError>
+where
+    S: FundingStore,
+    D: ChainDriver,
+{
+    authorize(&headers, &service.config().token)?;
+    service.health().await?;
+    Ok(Json(Health { status: "ok" }))
+}
+
+#[derive(Serialize)]
+struct Health {
+    status: &'static str,
+}
+
+fn authorize(headers: &HeaderMap, expected: &str) -> Result<(), ServiceError> {
+    let provided = headers
+        .get(header::AUTHORIZATION)
+        .and_then(|value| value.to_str().ok())
+        .and_then(|value| value.strip_prefix("Bearer "))
+        .unwrap_or_default();
+    let provided_hash = Sha256::digest(provided.as_bytes());
+    let expected_hash = Sha256::digest(expected.as_bytes());
+    if bool::from(provided_hash.as_slice().ct_eq(expected_hash.as_slice())) {
+        Ok(())
+    } else {
+        Err(ServiceError::new(
+            401,
+            "unauthorized",
+            "Invalid bearer token",
+        ))
+    }
+}
+
+fn validate_common(
+    idempotency_key: String,
+    recipient_text: String,
+    reason: String,
+) -> Result<FundingInput, ServiceError> {
+    static IDEMPOTENCY: OnceLock<Regex> = OnceLock::new();
+    static REASON: OnceLock<Regex> = OnceLock::new();
+    if !IDEMPOTENCY
+        .get_or_init(|| Regex::new(IDEMPOTENCY_PATTERN).unwrap())
+        .is_match(&idempotency_key)
+    {
+        return Err(ServiceError::new(
+            400,
+            "invalid_idempotency_key",
+            "idempotency_key must contain 1-128 letters, numbers, '.', '_', ':', or '-'",
+        ));
+    }
+    let recipient = Address::from_str(&recipient_text).map_err(|_| {
+        ServiceError::new(
+            400,
+            "invalid_recipient",
+            "recipient must be a non-zero EVM address",
+        )
+    })?;
+    if recipient == Address::ZERO {
+        return Err(ServiceError::new(
+            400,
+            "invalid_recipient",
+            "recipient must be a non-zero EVM address",
+        ));
+    }
+    if !REASON
+        .get_or_init(|| Regex::new(REASON_PATTERN).unwrap())
+        .is_match(&reason)
+    {
+        return Err(ServiceError::new(
+            400,
+            "invalid_reason",
+            "reason must contain 1-64 letters, numbers, '.', '_', ':', or '-'",
+        ));
+    }
+    Ok(FundingInput {
+        asset: FundingAsset::Susdc,
+        idempotency_key,
+        recipient,
+        recipient_text: recipient.to_checksum(None),
+        amount: U256::ZERO,
+        reason,
+    })
+}
+
+fn parse_amount(value: &str, maximum: U256) -> Result<U256, ServiceError> {
+    if value.is_empty()
+        || value.starts_with('0')
+        || !value.bytes().all(|byte| byte.is_ascii_digit())
+    {
+        return Err(ServiceError::new(
+            400,
+            "invalid_amount",
+            "amount must be a positive decimal string in 6-decimal base units",
+        ));
+    }
+    let amount = U256::from_str_radix(value, 10).map_err(|_| {
+        ServiceError::new(
+            400,
+            "invalid_amount",
+            "amount must be a positive decimal string in 6-decimal base units",
+        )
+    })?;
+    if amount > maximum {
+        return Err(ServiceError::new(
+            400,
+            "amount_exceeds_limit",
+            format!("amount exceeds the configured limit of {maximum}"),
+        ));
+    }
+    Ok(amount)
+}
+
+fn invalid_json(_: JsonRejection) -> ServiceError {
+    ServiceError::new(400, "invalid_request", "Invalid JSON body")
+}
+
+impl IntoResponse for ServiceError {
+    fn into_response(self) -> Response {
+        let status = StatusCode::from_u16(self.status).unwrap_or(StatusCode::INTERNAL_SERVER_ERROR);
+        let retry_after_seconds = self.retry_after_seconds;
+        let mut response = (
+            status,
+            Json(ErrorEnvelope {
+                error: ErrorBody {
+                    code: self.code,
+                    message: self.message,
+                    retry_after_seconds,
+                    transaction_hash: self.transaction_hash,
+                },
+            }),
+        )
+            .into_response();
+        if let Some(seconds) = retry_after_seconds {
+            if let Ok(value) = HeaderValue::from_str(&seconds.to_string()) {
+                response.headers_mut().insert(header::RETRY_AFTER, value);
+            }
+        }
+        response
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn authorization_compares_fixed_length_hashes() {
+        let token = "a-secure-machine-token-with-32-characters";
+        let mut headers = HeaderMap::new();
+        headers.insert(
+            header::AUTHORIZATION,
+            format!("Bearer {token}").parse().unwrap(),
+        );
+        assert!(authorize(&headers, token).is_ok());
+        headers.insert(header::AUTHORIZATION, "Bearer wrong".parse().unwrap());
+        assert_eq!(authorize(&headers, token).unwrap_err().status, 401);
+    }
+
+    #[test]
+    fn validates_addresses_and_decimal_base_units() {
+        let input = validate_common(
+            "order-123".into(),
+            "0x00000000000000000000000000000000000000a1".into(),
+            "order_payout".into(),
+        )
+        .unwrap();
+        assert_eq!(
+            input.recipient_text,
+            "0x00000000000000000000000000000000000000A1"
+        );
+        assert_eq!(
+            parse_amount("12500000", U256::from(250_000_000u64)).unwrap(),
+            U256::from(12_500_000u64)
+        );
+        assert!(parse_amount("0", U256::MAX).is_err());
+        assert!(parse_amount("01", U256::MAX).is_err());
+    }
+}

--- a/machine-funding-server/src/lib.rs
+++ b/machine-funding-server/src/lib.rs
@@ -1,1 +1,12 @@
+pub mod chain;
+pub mod config;
+pub mod http;
+pub mod model;
+pub mod service;
+pub mod store;
 
+pub use chain::{ChainDriver, EvmChainDriver};
+pub use config::Config;
+pub use http::router;
+pub use service::FundingService;
+pub use store::RedisStore;

--- a/machine-funding-server/src/main.rs
+++ b/machine-funding-server/src/main.rs
@@ -1,0 +1,42 @@
+use faucet_machine_funding::store::FundingStore;
+use faucet_machine_funding::{router, Config, EvmChainDriver, FundingService, RedisStore};
+use tokio::{net::TcpListener, signal};
+use tracing_subscriber::EnvFilter;
+
+#[tokio::main]
+async fn main() -> Result<(), Box<dyn std::error::Error>> {
+    tracing_subscriber::fmt()
+        .with_env_filter(EnvFilter::try_from_default_env().unwrap_or_else(|_| "info".into()))
+        .init();
+    let config = Config::from_env()?;
+    let store = RedisStore::connect(&config.redis_url).await?;
+    store.verify_durability().await?;
+    let driver = EvmChainDriver::connect(&config).await?;
+    let bind_addr = config.bind_addr;
+    let service = FundingService::new(store, driver, config);
+    service.health().await?;
+    let listener = TcpListener::bind(bind_addr).await?;
+    tracing::info!(%bind_addr, "machine funding service listening");
+    axum::serve(listener, router(service))
+        .with_graceful_shutdown(shutdown_signal())
+        .await?;
+    Ok(())
+}
+
+async fn shutdown_signal() {
+    let ctrl_c = async { signal::ctrl_c().await.expect("install Ctrl-C handler") };
+    #[cfg(unix)]
+    let terminate = async {
+        signal::unix::signal(signal::unix::SignalKind::terminate())
+            .expect("install SIGTERM handler")
+            .recv()
+            .await;
+    };
+    #[cfg(not(unix))]
+    let terminate = std::future::pending::<()>();
+    tokio::select! {
+        () = ctrl_c => {},
+        () = terminate => {},
+    }
+    tracing::info!("machine funding service shutting down");
+}

--- a/machine-funding-server/src/model.rs
+++ b/machine-funding-server/src/model.rs
@@ -1,0 +1,210 @@
+use alloy_primitives::{Address, U256};
+use serde::{Deserialize, Serialize};
+use thiserror::Error;
+
+#[derive(Clone, Copy, Debug, Deserialize, Serialize, PartialEq, Eq)]
+#[serde(rename_all = "lowercase")]
+pub enum FundingAsset {
+    Susdc,
+    Native,
+}
+
+impl FundingAsset {
+    pub fn key(self) -> &'static str {
+        match self {
+            Self::Susdc => "susdc",
+            Self::Native => "native",
+        }
+    }
+}
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct FundingInput {
+    pub asset: FundingAsset,
+    pub idempotency_key: String,
+    pub recipient: Address,
+    pub recipient_text: String,
+    pub amount: U256,
+    pub reason: String,
+}
+
+#[derive(Clone, Debug, Deserialize, Serialize, PartialEq, Eq)]
+pub struct PersistedInput {
+    pub asset: FundingAsset,
+    pub idempotency_key: String,
+    pub recipient: String,
+    pub amount: String,
+    pub reason: String,
+}
+
+impl From<&FundingInput> for PersistedInput {
+    fn from(input: &FundingInput) -> Self {
+        Self {
+            asset: input.asset,
+            idempotency_key: input.idempotency_key.clone(),
+            recipient: input.recipient_text.clone(),
+            amount: input.amount.to_string(),
+            reason: input.reason.clone(),
+        }
+    }
+}
+
+impl TryFrom<&PersistedInput> for FundingInput {
+    type Error = ServiceError;
+
+    fn try_from(input: &PersistedInput) -> Result<Self, Self::Error> {
+        let recipient = input
+            .recipient
+            .parse()
+            .map_err(|_| ServiceError::internal())?;
+        let amount =
+            U256::from_str_radix(&input.amount, 10).map_err(|_| ServiceError::internal())?;
+        Ok(Self {
+            asset: input.asset,
+            idempotency_key: input.idempotency_key.clone(),
+            recipient,
+            recipient_text: input.recipient.clone(),
+            amount,
+            reason: input.reason.clone(),
+        })
+    }
+}
+
+#[derive(Clone, Debug, Deserialize, Serialize, PartialEq, Eq)]
+pub struct PreparedTransaction {
+    pub hash: String,
+    pub nonce: u64,
+    pub serialized_transaction: String,
+}
+
+#[derive(Clone, Debug, Deserialize, Serialize, PartialEq, Eq)]
+pub struct FundingResponse {
+    pub idempotency_key: String,
+    pub recipient: String,
+    pub amount: String,
+    pub transaction_hash: String,
+    pub replayed: bool,
+}
+
+#[derive(Clone, Debug, Deserialize, Serialize, PartialEq, Eq)]
+#[serde(tag = "state", rename_all = "lowercase")]
+pub enum FundingRecord {
+    Queued {
+        fingerprint: String,
+        input: PersistedInput,
+    },
+    Prepared {
+        fingerprint: String,
+        input: PersistedInput,
+        transaction: PreparedTransaction,
+    },
+    Completed {
+        fingerprint: String,
+        input: PersistedInput,
+        transaction: PreparedTransaction,
+        response: FundingResponse,
+    },
+    Failed {
+        fingerprint: String,
+        input: PersistedInput,
+        transaction: PreparedTransaction,
+        code: String,
+        message: String,
+        transaction_hash: String,
+    },
+}
+
+impl FundingRecord {
+    pub fn fingerprint(&self) -> &str {
+        match self {
+            Self::Queued { fingerprint, .. }
+            | Self::Prepared { fingerprint, .. }
+            | Self::Completed { fingerprint, .. }
+            | Self::Failed { fingerprint, .. } => fingerprint,
+        }
+    }
+}
+
+#[derive(Clone, Debug, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct SusdcRequest {
+    pub idempotency_key: String,
+    pub recipient: String,
+    pub amount: String,
+    pub reason: String,
+}
+
+#[derive(Clone, Debug, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct GasRequest {
+    pub idempotency_key: String,
+    pub recipient: String,
+    pub reason: String,
+}
+
+#[derive(Clone, Debug, Serialize)]
+pub struct ErrorEnvelope {
+    pub error: ErrorBody,
+}
+
+#[derive(Clone, Debug, Serialize)]
+pub struct ErrorBody {
+    pub code: String,
+    pub message: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub retry_after_seconds: Option<u64>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub transaction_hash: Option<String>,
+}
+
+#[derive(Clone, Debug, Error)]
+#[error("{message}")]
+pub struct ServiceError {
+    pub status: u16,
+    pub code: String,
+    pub message: String,
+    pub retry_after_seconds: Option<u64>,
+    pub transaction_hash: Option<String>,
+}
+
+impl ServiceError {
+    pub fn new(status: u16, code: impl Into<String>, message: impl Into<String>) -> Self {
+        Self {
+            status,
+            code: code.into(),
+            message: message.into(),
+            retry_after_seconds: None,
+            transaction_hash: None,
+        }
+    }
+
+    pub fn retry(mut self, seconds: u64) -> Self {
+        self.retry_after_seconds = Some(seconds);
+        self
+    }
+
+    pub fn transaction(mut self, hash: impl Into<String>) -> Self {
+        self.transaction_hash = Some(hash.into());
+        self
+    }
+
+    pub fn internal() -> Self {
+        Self::new(500, "internal_error", "Machine funding state is invalid")
+    }
+}
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub enum ChainResult {
+    Success,
+    Reverted,
+    Pending,
+    Rejected(String),
+}
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub enum ReservationResult {
+    Reserved,
+    Existing,
+    RecipientRateLimited(u64),
+    GlobalBudgetExceeded(u64),
+}

--- a/machine-funding-server/src/service.rs
+++ b/machine-funding-server/src/service.rs
@@ -1,0 +1,465 @@
+use crate::{
+    chain::ChainDriver,
+    config::Config,
+    model::{
+        ChainResult, FundingAsset, FundingInput, FundingRecord, FundingResponse, PersistedInput,
+        ReservationResult, ServiceError,
+    },
+    store::{FundingStore, Reservation},
+};
+use alloy_primitives::U256;
+use sha2::{Digest, Sha256};
+use std::time::Duration;
+use tokio::{
+    sync::oneshot,
+    time::{sleep, timeout, Instant},
+};
+use uuid::Uuid;
+
+const LOCK_TTL_BUFFER: Duration = Duration::from_secs(60);
+const LOCK_RETRY_INTERVAL: Duration = Duration::from_millis(25);
+
+#[derive(Clone)]
+pub struct FundingService<S, D> {
+    store: S,
+    driver: D,
+    config: Config,
+}
+
+struct OperatorLockGuard<S: FundingStore> {
+    store: S,
+    key: String,
+    token: String,
+    armed: bool,
+}
+
+impl<S: FundingStore> OperatorLockGuard<S> {
+    fn new(store: S, key: String, token: String) -> Self {
+        Self {
+            store,
+            key,
+            token,
+            armed: true,
+        }
+    }
+
+    async fn release(mut self) {
+        self.armed = false;
+        if let Err(error) = self.store.release_lock(&self.key, &self.token).await {
+            tracing::error!(%error, "failed to release machine funding operator lock");
+        }
+    }
+
+    fn disarm(mut self) {
+        self.armed = false;
+    }
+
+    fn key(&self) -> &str {
+        &self.key
+    }
+
+    fn token(&self) -> &str {
+        &self.token
+    }
+}
+
+impl<S: FundingStore> Drop for OperatorLockGuard<S> {
+    fn drop(&mut self) {
+        if !self.armed {
+            return;
+        }
+        let store = self.store.clone();
+        let key = self.key.clone();
+        let token = self.token.clone();
+        tokio::spawn(async move {
+            if let Err(error) = store.release_lock(&key, &token).await {
+                tracing::error!(%error, "failed to release cancelled machine funding operator lock");
+            }
+        });
+    }
+}
+
+impl<S, D> FundingService<S, D>
+where
+    S: FundingStore,
+    D: ChainDriver,
+{
+    pub fn new(store: S, driver: D, config: Config) -> Self {
+        Self {
+            store,
+            driver,
+            config,
+        }
+    }
+
+    pub fn config(&self) -> &Config {
+        &self.config
+    }
+
+    pub async fn health(&self) -> Result<(), ServiceError> {
+        tokio::try_join!(self.store.ping(), self.driver.health()).map(|_| ())
+    }
+
+    pub async fn execute(&self, input: FundingInput) -> Result<FundingResponse, ServiceError> {
+        match timeout(self.config.request_timeout, self.execute_inner(input)).await {
+            Ok(result) => result,
+            Err(_) => Err(ServiceError::new(
+                504,
+                "request_timeout",
+                "Machine funding exceeded its request deadline and can be retried unchanged",
+            )
+            .retry(1)),
+        }
+    }
+
+    async fn execute_inner(&self, input: FundingInput) -> Result<FundingResponse, ServiceError> {
+        let record_key = record_key(&input.idempotency_key);
+        let fingerprint = fingerprint(&input);
+        let queue_key = queue_key(self.driver.operator_key());
+        let queued = FundingRecord::Queued {
+            fingerprint: fingerprint.clone(),
+            input: PersistedInput::from(&input),
+        };
+        let amount = input.amount.to_string();
+        let budget = self.global_budget(input.asset).to_string();
+        let recipient_rate_key = recipient_rate_key(&input);
+        let global_budget_key = global_budget_key(input.asset);
+        let reservation = self
+            .store
+            .reserve(Reservation {
+                record_key: &record_key,
+                queue_key: &queue_key,
+                recipient_rate_key: &recipient_rate_key,
+                global_budget_key: &global_budget_key,
+                record: &queued,
+                amount: &amount,
+                global_budget: &budget,
+                recipient_limit: self.config.rate_limit,
+                window_seconds: self.config.rate_window.as_secs(),
+            })
+            .await?;
+        match reservation {
+            ReservationResult::RecipientRateLimited(seconds) => {
+                return Err(ServiceError::new(
+                    429,
+                    "rate_limited",
+                    "Recipient funding rate limit exceeded",
+                )
+                .retry(seconds));
+            }
+            ReservationResult::GlobalBudgetExceeded(seconds) => {
+                return Err(ServiceError::new(
+                    429,
+                    "global_budget_exceeded",
+                    "Global funding budget exceeded",
+                )
+                .retry(seconds));
+            }
+            ReservationResult::Reserved | ReservationResult::Existing => {}
+        }
+
+        let existing = self
+            .store
+            .get_record(&record_key)
+            .await?
+            .ok_or_else(ServiceError::internal)?;
+        if existing.fingerprint() != fingerprint {
+            return Err(ServiceError::new(
+                409,
+                "idempotency_conflict",
+                "idempotency_key was already used for a different request",
+            ));
+        }
+        if let Some(response) = terminal_result(&existing, true)? {
+            return Ok(response);
+        }
+
+        let lock_guard = self
+            .acquire_lock(lock_key(self.driver.operator_key()))
+            .await?;
+        let result = self
+            .execute_with_lease(
+                lock_guard.key(),
+                lock_guard.token(),
+                &record_key,
+                &queue_key,
+                &fingerprint,
+            )
+            .await;
+        lock_guard.release().await;
+        result
+    }
+
+    async fn execute_with_lease(
+        &self,
+        lock_key: &str,
+        lock_token: &str,
+        record_key: &str,
+        queue_key: &str,
+        fingerprint: &str,
+    ) -> Result<FundingResponse, ServiceError> {
+        let ttl = self.config.receipt_timeout + LOCK_TTL_BUFFER;
+        let renewal_interval = ttl / 3;
+        let store = self.store.clone();
+        let lease_key = lock_key.to_owned();
+        let lease_token = lock_token.to_owned();
+        let (stop_sender, mut stop_receiver) = oneshot::channel();
+        let (failure_sender, mut failure_receiver) = oneshot::channel();
+        let lease = tokio::spawn(async move {
+            loop {
+                tokio::select! {
+                    _ = sleep(renewal_interval) => {
+                        match store.renew_lock(&lease_key, &lease_token, ttl.as_millis() as u64).await {
+                            Ok(true) => {}
+                            Ok(false) => {
+                                let _ = failure_sender.send(ServiceError::new(
+                                    503,
+                                    "operator_lease_lost",
+                                    "Machine funding operator lease was lost",
+                                ).retry(1));
+                                return;
+                            }
+                            Err(error) => {
+                                let _ = failure_sender.send(error);
+                                return;
+                            }
+                        }
+                    }
+                    _ = &mut stop_receiver => return,
+                }
+            }
+        });
+        let operation = self.execute_locked(record_key, queue_key, fingerprint);
+        tokio::pin!(operation);
+        let result = tokio::select! {
+            result = &mut operation => result,
+            lease_failure = &mut failure_receiver => {
+                Err(lease_failure.unwrap_or_else(|_| ServiceError::new(
+                    503,
+                    "operator_lease_lost",
+                    "Machine funding operator lease was lost",
+                ).retry(1)))
+            }
+        };
+        let _ = stop_sender.send(());
+        let _ = lease.await;
+        result
+    }
+
+    async fn acquire_lock(&self, key: String) -> Result<OperatorLockGuard<S>, ServiceError> {
+        let deadline = Instant::now() + self.config.lock_wait;
+        let ttl = self.config.receipt_timeout + LOCK_TTL_BUFFER;
+        loop {
+            let guard =
+                OperatorLockGuard::new(self.store.clone(), key.clone(), Uuid::new_v4().to_string());
+            if self
+                .store
+                .acquire_lock(guard.key(), guard.token(), ttl.as_millis() as u64)
+                .await?
+            {
+                return Ok(guard);
+            }
+            guard.disarm();
+            if Instant::now() >= deadline {
+                return Err(ServiceError::new(
+                    409,
+                    "operator_busy",
+                    "The machine funding operator is processing another transaction",
+                )
+                .retry(1));
+            }
+            sleep(LOCK_RETRY_INTERVAL).await;
+        }
+    }
+
+    async fn execute_locked(
+        &self,
+        request_record_key: &str,
+        queue: &str,
+        fingerprint: &str,
+    ) -> Result<FundingResponse, ServiceError> {
+        let current = self
+            .store
+            .get_record(request_record_key)
+            .await?
+            .ok_or_else(ServiceError::internal)?;
+        if current.fingerprint() != fingerprint {
+            return Err(ServiceError::new(
+                409,
+                "idempotency_conflict",
+                "idempotency_key was already used for a different request",
+            ));
+        }
+        if let Some(response) = terminal_result(&current, true)? {
+            return Ok(response);
+        }
+
+        let head = self
+            .store
+            .queue_head(queue)
+            .await?
+            .ok_or_else(ServiceError::internal)?;
+        let processed = self.process_head(queue, &head).await?;
+        if head != request_record_key {
+            return Err(ServiceError::new(
+                409,
+                "request_queued",
+                "The request is queued behind another machine funding transaction",
+            )
+            .retry(1));
+        }
+        terminal_result(&processed, false)?.ok_or_else(ServiceError::internal)
+    }
+
+    async fn process_head(
+        &self,
+        queue: &str,
+        record_key: &str,
+    ) -> Result<FundingRecord, ServiceError> {
+        let mut record = match self.store.get_record(record_key).await? {
+            Some(record) => record,
+            None => {
+                self.store.pop_queue_head(queue, record_key).await?;
+                return Err(ServiceError::internal());
+            }
+        };
+        if matches!(
+            record,
+            FundingRecord::Completed { .. } | FundingRecord::Failed { .. }
+        ) {
+            self.store.pop_queue_head(queue, record_key).await?;
+            return Ok(record);
+        }
+
+        if let FundingRecord::Queued { fingerprint, input } = record {
+            let nonce = self.driver.pending_nonce().await?;
+            let transaction = self
+                .driver
+                .prepare(&FundingInput::try_from(&input)?, nonce)
+                .await?;
+            record = FundingRecord::Prepared {
+                fingerprint,
+                input,
+                transaction,
+            };
+            self.store.set_record(record_key, &record).await?;
+        }
+
+        let (fingerprint, input, transaction) = match &record {
+            FundingRecord::Prepared {
+                fingerprint,
+                input,
+                transaction,
+            } => (fingerprint.clone(), input.clone(), transaction.clone()),
+            _ => return Err(ServiceError::internal()),
+        };
+        let result = self.driver.broadcast_and_confirm(&transaction).await?;
+        let terminal = match result {
+            ChainResult::Pending => {
+                return Err(ServiceError::new(
+                    504,
+                    "transaction_pending",
+                    "The signed transaction is pending confirmation and will be retried unchanged",
+                )
+                .retry(1)
+                .transaction(transaction.hash));
+            }
+            ChainResult::Reverted => FundingRecord::Failed {
+                fingerprint,
+                input,
+                transaction: transaction.clone(),
+                code: "transaction_reverted".into(),
+                message: "The funding transaction reverted".into(),
+                transaction_hash: transaction.hash,
+            },
+            ChainResult::Rejected(message) => FundingRecord::Failed {
+                fingerprint,
+                input,
+                transaction: transaction.clone(),
+                code: "transaction_rejected".into(),
+                message,
+                transaction_hash: transaction.hash,
+            },
+            ChainResult::Success => {
+                let response = FundingResponse {
+                    idempotency_key: input.idempotency_key.clone(),
+                    recipient: input.recipient.clone(),
+                    amount: input.amount.clone(),
+                    transaction_hash: transaction.hash.clone(),
+                    replayed: false,
+                };
+                FundingRecord::Completed {
+                    fingerprint,
+                    input,
+                    transaction,
+                    response,
+                }
+            }
+        };
+        self.store.set_record(record_key, &terminal).await?;
+        self.store.pop_queue_head(queue, record_key).await?;
+        Ok(terminal)
+    }
+
+    fn global_budget(&self, asset: FundingAsset) -> U256 {
+        match asset {
+            FundingAsset::Susdc => self.config.global_susdc_budget,
+            FundingAsset::Native => self.config.global_gas_budget_wei,
+        }
+    }
+}
+
+fn terminal_result(
+    record: &FundingRecord,
+    replayed: bool,
+) -> Result<Option<FundingResponse>, ServiceError> {
+    match record {
+        FundingRecord::Completed { response, .. } => {
+            let mut response = response.clone();
+            response.replayed = replayed;
+            Ok(Some(response))
+        }
+        FundingRecord::Failed {
+            code,
+            message,
+            transaction_hash,
+            ..
+        } => Err(ServiceError::new(422, code, message).transaction(transaction_hash)),
+        FundingRecord::Queued { .. } | FundingRecord::Prepared { .. } => Ok(None),
+    }
+}
+
+fn record_key(idempotency_key: &str) -> String {
+    format!("machine-funding:idempotency:{idempotency_key}")
+}
+
+fn queue_key(operator_key: &str) -> String {
+    format!("machine-funding:queue:{operator_key}")
+}
+
+fn lock_key(operator_key: &str) -> String {
+    format!("machine-funding:lock:{operator_key}")
+}
+
+fn recipient_rate_key(input: &FundingInput) -> String {
+    format!(
+        "machine-funding:rate:{}:{}",
+        input.asset.key(),
+        input.recipient_text.to_ascii_lowercase()
+    )
+}
+
+fn global_budget_key(asset: FundingAsset) -> String {
+    format!("machine-funding:budget:{}", asset.key())
+}
+
+fn fingerprint(input: &FundingInput) -> String {
+    let value = format!(
+        "{}\n{}\n{}\n{}",
+        input.asset.key(),
+        input.recipient_text.to_ascii_lowercase(),
+        input.amount,
+        input.reason
+    );
+    hex::encode(Sha256::digest(value.as_bytes()))
+}

--- a/machine-funding-server/src/store.rs
+++ b/machine-funding-server/src/store.rs
@@ -1,0 +1,261 @@
+use crate::model::{FundingRecord, ReservationResult, ServiceError};
+use async_trait::async_trait;
+use redis::{
+    aio::{ConnectionManager, ConnectionManagerConfig},
+    AsyncCommands, Script,
+};
+use std::time::Duration;
+
+const REDIS_RESPONSE_TIMEOUT: Duration = Duration::from_secs(2);
+const REDIS_CONNECTION_TIMEOUT: Duration = Duration::from_secs(2);
+
+const RESERVE_AND_ENQUEUE_SCRIPT: &str = r#"
+if redis.call('EXISTS', KEYS[1]) == 1 then return {0, 0} end
+local recipientCount = tonumber(redis.call('GET', KEYS[3]) or '0')
+if recipientCount >= tonumber(ARGV[3]) then return {-1, redis.call('TTL', KEYS[3])} end
+local globalExisted = redis.call('EXISTS', KEYS[4])
+redis.call('INCRBY', KEYS[4], ARGV[4])
+local globalAmount = redis.call('GET', KEYS[4])
+local function greaterThan(left, right)
+  left = string.gsub(left, '^0+', '')
+  right = string.gsub(right, '^0+', '')
+  if string.len(left) ~= string.len(right) then return string.len(left) > string.len(right) end
+  return left > right
+end
+if greaterThan(globalAmount, ARGV[5]) then
+  redis.call('DECRBY', KEYS[4], ARGV[4])
+  if globalExisted == 0 then redis.call('DEL', KEYS[4]) end
+  return {-2, redis.call('TTL', KEYS[4])}
+end
+local newRecipientCount = redis.call('INCR', KEYS[3])
+if newRecipientCount == 1 then redis.call('EXPIRE', KEYS[3], ARGV[2]) end
+if globalExisted == 0 then redis.call('EXPIRE', KEYS[4], ARGV[2]) end
+redis.call('SET', KEYS[1], ARGV[1])
+redis.call('RPUSH', KEYS[2], KEYS[1])
+return {1, 0}
+"#;
+const POP_QUEUE_HEAD_SCRIPT: &str = r#"
+if redis.call('LINDEX', KEYS[1], 0) == ARGV[1] then
+  redis.call('LPOP', KEYS[1])
+  return 1
+end
+return 0
+"#;
+const RELEASE_LOCK_SCRIPT: &str = r#"
+if redis.call('GET', KEYS[1]) == ARGV[1] then return redis.call('DEL', KEYS[1]) end
+return 0
+"#;
+const RENEW_LOCK_SCRIPT: &str = r#"
+if redis.call('GET', KEYS[1]) == ARGV[1] then return redis.call('PEXPIRE', KEYS[1], ARGV[2]) end
+return 0
+"#;
+
+#[derive(Clone)]
+pub struct RedisStore {
+    connection: ConnectionManager,
+}
+
+pub struct Reservation<'a> {
+    pub record_key: &'a str,
+    pub queue_key: &'a str,
+    pub recipient_rate_key: &'a str,
+    pub global_budget_key: &'a str,
+    pub record: &'a FundingRecord,
+    pub amount: &'a str,
+    pub global_budget: &'a str,
+    pub recipient_limit: u64,
+    pub window_seconds: u64,
+}
+
+#[async_trait]
+pub trait FundingStore: Clone + Send + Sync + 'static {
+    async fn reserve(
+        &self,
+        reservation: Reservation<'_>,
+    ) -> Result<ReservationResult, ServiceError>;
+    async fn get_record(&self, key: &str) -> Result<Option<FundingRecord>, ServiceError>;
+    async fn set_record(&self, key: &str, record: &FundingRecord) -> Result<(), ServiceError>;
+    async fn queue_head(&self, key: &str) -> Result<Option<String>, ServiceError>;
+    async fn pop_queue_head(&self, key: &str, expected: &str) -> Result<(), ServiceError>;
+    async fn acquire_lock(&self, key: &str, token: &str, ttl_ms: u64)
+        -> Result<bool, ServiceError>;
+    async fn release_lock(&self, key: &str, token: &str) -> Result<(), ServiceError>;
+    async fn renew_lock(&self, key: &str, token: &str, ttl_ms: u64) -> Result<bool, ServiceError>;
+    async fn ping(&self) -> Result<(), ServiceError>;
+    async fn verify_durability(&self) -> Result<(), ServiceError>;
+}
+
+impl RedisStore {
+    pub async fn connect(url: &str) -> Result<Self, ServiceError> {
+        let client = redis::Client::open(url).map_err(store_error)?;
+        let manager_config = ConnectionManagerConfig::new()
+            .set_number_of_retries(1)
+            .set_response_timeout(REDIS_RESPONSE_TIMEOUT)
+            .set_connection_timeout(REDIS_CONNECTION_TIMEOUT);
+        let connection = ConnectionManager::new_with_config(client, manager_config)
+            .await
+            .map_err(store_error)?;
+        Ok(Self { connection })
+    }
+}
+
+#[async_trait]
+impl FundingStore for RedisStore {
+    async fn reserve(
+        &self,
+        reservation: Reservation<'_>,
+    ) -> Result<ReservationResult, ServiceError> {
+        let record = serde_json::to_string(reservation.record).map_err(store_error)?;
+        let result: (i64, i64) = Script::new(RESERVE_AND_ENQUEUE_SCRIPT)
+            .key(reservation.record_key)
+            .key(reservation.queue_key)
+            .key(reservation.recipient_rate_key)
+            .key(reservation.global_budget_key)
+            .arg(record)
+            .arg(reservation.window_seconds)
+            .arg(reservation.recipient_limit)
+            .arg(reservation.amount)
+            .arg(reservation.global_budget)
+            .invoke_async(&mut self.connection.clone())
+            .await
+            .map_err(store_error)?;
+        let retry = result.1.max(1) as u64;
+        match result.0 {
+            1 => Ok(ReservationResult::Reserved),
+            0 => Ok(ReservationResult::Existing),
+            -1 => Ok(ReservationResult::RecipientRateLimited(retry)),
+            -2 => Ok(ReservationResult::GlobalBudgetExceeded(retry)),
+            _ => Err(store_error("unexpected reservation result")),
+        }
+    }
+
+    async fn get_record(&self, key: &str) -> Result<Option<FundingRecord>, ServiceError> {
+        let value: Option<String> = self
+            .connection
+            .clone()
+            .get(key)
+            .await
+            .map_err(store_error)?;
+        value
+            .map(|raw| serde_json::from_str(&raw).map_err(store_error))
+            .transpose()
+    }
+
+    async fn set_record(&self, key: &str, record: &FundingRecord) -> Result<(), ServiceError> {
+        let value = serde_json::to_string(record).map_err(store_error)?;
+        self.connection
+            .clone()
+            .set::<_, _, ()>(key, value)
+            .await
+            .map_err(store_error)
+    }
+
+    async fn queue_head(&self, key: &str) -> Result<Option<String>, ServiceError> {
+        self.connection
+            .clone()
+            .lindex(key, 0)
+            .await
+            .map_err(store_error)
+    }
+
+    async fn pop_queue_head(&self, key: &str, expected: &str) -> Result<(), ServiceError> {
+        Script::new(POP_QUEUE_HEAD_SCRIPT)
+            .key(key)
+            .arg(expected)
+            .invoke_async::<i64>(&mut self.connection.clone())
+            .await
+            .map(|_| ())
+            .map_err(store_error)
+    }
+
+    async fn acquire_lock(
+        &self,
+        key: &str,
+        token: &str,
+        ttl_ms: u64,
+    ) -> Result<bool, ServiceError> {
+        let result: Option<String> = redis::cmd("SET")
+            .arg(key)
+            .arg(token)
+            .arg("PX")
+            .arg(ttl_ms)
+            .arg("NX")
+            .query_async(&mut self.connection.clone())
+            .await
+            .map_err(store_error)?;
+        Ok(result.as_deref() == Some("OK"))
+    }
+
+    async fn release_lock(&self, key: &str, token: &str) -> Result<(), ServiceError> {
+        Script::new(RELEASE_LOCK_SCRIPT)
+            .key(key)
+            .arg(token)
+            .invoke_async::<i64>(&mut self.connection.clone())
+            .await
+            .map(|_| ())
+            .map_err(store_error)
+    }
+
+    async fn renew_lock(&self, key: &str, token: &str, ttl_ms: u64) -> Result<bool, ServiceError> {
+        Script::new(RENEW_LOCK_SCRIPT)
+            .key(key)
+            .arg(token)
+            .arg(ttl_ms)
+            .invoke_async::<i64>(&mut self.connection.clone())
+            .await
+            .map(|renewed| renewed == 1)
+            .map_err(store_error)
+    }
+
+    async fn ping(&self) -> Result<(), ServiceError> {
+        redis::cmd("PING")
+            .query_async::<String>(&mut self.connection.clone())
+            .await
+            .map(|_| ())
+            .map_err(store_error)
+    }
+
+    async fn verify_durability(&self) -> Result<(), ServiceError> {
+        let append_only = redis_config_value(&self.connection, "appendonly").await?;
+        let append_fsync = redis_config_value(&self.connection, "appendfsync").await?;
+        if append_only != "yes" || append_fsync != "always" {
+            tracing::error!(%append_only, %append_fsync, "Redis durability policy is unsafe for machine funding");
+            return Err(ServiceError::new(
+                503,
+                "unsafe_state_configuration",
+                "Machine funding requires Redis appendonly=yes and appendfsync=always",
+            ));
+        }
+        Ok(())
+    }
+}
+
+async fn redis_config_value(
+    connection: &ConnectionManager,
+    name: &str,
+) -> Result<String, ServiceError> {
+    let values: Vec<String> = redis::cmd("CONFIG")
+        .arg("GET")
+        .arg(name)
+        .query_async(&mut connection.clone())
+        .await
+        .map_err(store_error)?;
+    values
+        .get(1)
+        .cloned()
+        .ok_or_else(store_error_missing_config)
+}
+
+fn store_error_missing_config() -> ServiceError {
+    store_error("Redis CONFIG GET returned no value")
+}
+
+fn store_error(error: impl std::fmt::Display) -> ServiceError {
+    tracing::error!(%error, "Redis funding state operation failed");
+    ServiceError::new(
+        503,
+        "state_unavailable",
+        "Machine funding state is unavailable",
+    )
+    .retry(1)
+}

--- a/machine-funding-server/tests/redis_semantics.rs
+++ b/machine-funding-server/tests/redis_semantics.rs
@@ -1,0 +1,450 @@
+use alloy_primitives::{Address, U256};
+use async_trait::async_trait;
+use axum::{
+    body::Body,
+    http::{header, Request, StatusCode},
+};
+use faucet_machine_funding::{
+    chain::ChainDriver,
+    model::{ChainResult, FundingAsset, FundingInput, PreparedTransaction, ServiceError},
+    router,
+    store::FundingStore,
+    Config, FundingService, RedisStore,
+};
+use http_body_util::BodyExt;
+use redis::AsyncCommands;
+use std::{
+    collections::VecDeque,
+    net::{SocketAddr, TcpListener},
+    process::{Child, Command, Stdio},
+    str::FromStr,
+    sync::{Arc, Mutex},
+    time::Duration,
+};
+use tempfile::TempDir;
+use tokio::time::sleep;
+use tower::ServiceExt;
+
+const RECIPIENT: &str = "0x00000000000000000000000000000000000000A1";
+
+struct TestRedis {
+    child: Child,
+    _directory: TempDir,
+    url: String,
+}
+
+impl TestRedis {
+    async fn start() -> Self {
+        Self::start_with_durability(true).await
+    }
+
+    async fn start_with_durability(durable: bool) -> Self {
+        let listener = TcpListener::bind("127.0.0.1:0").unwrap();
+        let port = listener.local_addr().unwrap().port();
+        drop(listener);
+        let directory = tempfile::tempdir().unwrap();
+        let mut child = Command::new("redis-server")
+            .args([
+                "--bind",
+                "127.0.0.1",
+                "--port",
+                &port.to_string(),
+                "--save",
+                "",
+                "--appendonly",
+                if durable { "yes" } else { "no" },
+                "--appendfsync",
+                if durable { "always" } else { "everysec" },
+                "--dir",
+                directory.path().to_str().unwrap(),
+            ])
+            .stdout(Stdio::null())
+            .stderr(Stdio::null())
+            .spawn()
+            .expect("redis-server must be installed for integration tests");
+        let url = format!("redis://127.0.0.1:{port}/");
+        for _ in 0..100 {
+            if RedisStore::connect(&url).await.is_ok() {
+                return Self {
+                    child,
+                    _directory: directory,
+                    url,
+                };
+            }
+            sleep(Duration::from_millis(20)).await;
+        }
+        let _ = child.kill();
+        let _ = child.wait();
+        panic!("Redis test server did not start");
+    }
+
+    async fn store(&self) -> RedisStore {
+        RedisStore::connect(&self.url).await.unwrap()
+    }
+
+    async fn raw_connection(&self) -> redis::aio::MultiplexedConnection {
+        redis::Client::open(self.url.as_str())
+            .unwrap()
+            .get_multiplexed_async_connection()
+            .await
+            .unwrap()
+    }
+}
+
+impl Drop for TestRedis {
+    fn drop(&mut self) {
+        let _ = self.child.kill();
+        let _ = self.child.wait();
+    }
+}
+
+#[derive(Clone)]
+struct FakeDriver {
+    inner: Arc<Mutex<FakeState>>,
+}
+
+struct FakeState {
+    results: VecDeque<ChainResult>,
+    prepared: Vec<PreparedTransaction>,
+    broadcasts: Vec<PreparedTransaction>,
+    prepare_delay: Duration,
+}
+
+impl FakeDriver {
+    fn new(results: impl IntoIterator<Item = ChainResult>) -> Self {
+        Self {
+            inner: Arc::new(Mutex::new(FakeState {
+                results: results.into_iter().collect(),
+                prepared: Vec::new(),
+                broadcasts: Vec::new(),
+                prepare_delay: Duration::ZERO,
+            })),
+        }
+    }
+
+    fn with_prepare_delay(self, delay: Duration) -> Self {
+        self.inner.lock().unwrap().prepare_delay = delay;
+        self
+    }
+
+    fn counts(&self) -> (usize, usize) {
+        let state = self.inner.lock().unwrap();
+        (state.prepared.len(), state.broadcasts.len())
+    }
+}
+
+#[async_trait]
+impl ChainDriver for FakeDriver {
+    fn operator_key(&self) -> &str {
+        "5124:0xmachine"
+    }
+
+    async fn pending_nonce(&self) -> Result<u64, ServiceError> {
+        Ok(self.inner.lock().unwrap().prepared.len() as u64)
+    }
+
+    async fn prepare(
+        &self,
+        _input: &FundingInput,
+        nonce: u64,
+    ) -> Result<PreparedTransaction, ServiceError> {
+        let delay = self.inner.lock().unwrap().prepare_delay;
+        sleep(delay).await;
+        let transaction = PreparedTransaction {
+            hash: format!("0x{:064x}", nonce + 1),
+            nonce,
+            serialized_transaction: format!("0x{:02x}", nonce + 1),
+        };
+        self.inner
+            .lock()
+            .unwrap()
+            .prepared
+            .push(transaction.clone());
+        Ok(transaction)
+    }
+
+    async fn broadcast_and_confirm(
+        &self,
+        transaction: &PreparedTransaction,
+    ) -> Result<ChainResult, ServiceError> {
+        let mut state = self.inner.lock().unwrap();
+        state.broadcasts.push(transaction.clone());
+        Ok(state.results.pop_front().unwrap_or(ChainResult::Success))
+    }
+
+    async fn health(&self) -> Result<(), ServiceError> {
+        Ok(())
+    }
+}
+
+fn config(redis_url: String) -> Config {
+    Config {
+        bind_addr: SocketAddr::from(([127, 0, 0, 1], 0)),
+        redis_url,
+        rpc_url: "http://127.0.0.1:8545".into(),
+        chain_id: 5124,
+        token: "a-secure-machine-token-with-32-characters".into(),
+        private_key: format!("0x{}", "1".repeat(64)),
+        funding_address: Address::from_str("0x19E7E376E7C213B7E7e7e46cc70A5dD086DAff2A").unwrap(),
+        faucet_address: Address::with_last_byte(1),
+        max_susdc_amount: U256::from(250_000_000u64),
+        gas_amount_wei: U256::from_str_radix("10000000000000000", 10).unwrap(),
+        global_susdc_budget: U256::from(1_000_000_000u64),
+        global_gas_budget_wei: U256::from_str_radix("1000000000000000000", 10).unwrap(),
+        rate_limit: 10,
+        rate_window: Duration::from_secs(60),
+        confirmations: 1,
+        receipt_timeout: Duration::from_millis(100),
+        lock_wait: Duration::from_secs(1),
+        request_timeout: Duration::from_secs(45),
+    }
+}
+
+fn request(key: &str, amount: u64) -> FundingInput {
+    FundingInput {
+        asset: FundingAsset::Susdc,
+        idempotency_key: key.into(),
+        recipient: Address::from_str(RECIPIENT).unwrap(),
+        recipient_text: RECIPIENT.into(),
+        amount: U256::from(amount),
+        reason: "order_payout".into(),
+    }
+}
+
+#[tokio::test]
+async fn rejects_redis_without_fsync_always() {
+    let redis = TestRedis::start_with_durability(false).await;
+    let store = redis.store().await;
+    let error = store.verify_durability().await.unwrap_err();
+    assert_eq!(error.code, "unsafe_state_configuration");
+}
+
+#[tokio::test]
+async fn renews_only_the_owned_operator_lock() {
+    let redis = TestRedis::start().await;
+    let store = redis.store().await;
+    assert!(store.acquire_lock("lease", "owner", 50).await.unwrap());
+    assert!(!store.renew_lock("lease", "stranger", 500).await.unwrap());
+    assert!(store.renew_lock("lease", "owner", 500).await.unwrap());
+    sleep(Duration::from_millis(100)).await;
+    assert!(!store.acquire_lock("lease", "second", 500).await.unwrap());
+    store.release_lock("lease", "owner").await.unwrap();
+}
+
+#[tokio::test]
+async fn concurrent_retries_sign_and_broadcast_once() {
+    let redis = TestRedis::start().await;
+    redis.store().await.verify_durability().await.unwrap();
+    let driver =
+        FakeDriver::new([ChainResult::Success]).with_prepare_delay(Duration::from_millis(50));
+    let service = FundingService::new(
+        redis.store().await,
+        driver.clone(),
+        config(redis.url.clone()),
+    );
+    let (first, second) = tokio::join!(
+        service.execute(request("order-123", 12_500_000)),
+        service.execute(request("order-123", 12_500_000)),
+    );
+    let first = first.unwrap();
+    let second = second.unwrap();
+    assert_eq!(first.transaction_hash, second.transaction_hash);
+    assert_ne!(first.replayed, second.replayed);
+    assert_eq!(driver.counts(), (1, 1));
+}
+
+#[tokio::test]
+async fn hard_request_deadline_releases_operator_lock() {
+    let redis = TestRedis::start().await;
+    let store = redis.store().await;
+    let driver =
+        FakeDriver::new([ChainResult::Success]).with_prepare_delay(Duration::from_millis(100));
+    let mut deadline = config(redis.url.clone());
+    deadline.request_timeout = Duration::from_millis(20);
+    let service = FundingService::new(store.clone(), driver, deadline);
+
+    let error = service
+        .execute(request("order-123", 12_500_000))
+        .await
+        .unwrap_err();
+    assert_eq!(error.code, "request_timeout");
+    sleep(Duration::from_millis(20)).await;
+    assert!(store
+        .acquire_lock("machine-funding:lock:5124:0xmachine", "probe", 100)
+        .await
+        .unwrap());
+}
+
+#[tokio::test]
+async fn pending_transaction_replays_identical_signed_bytes() {
+    let redis = TestRedis::start().await;
+    let driver = FakeDriver::new([ChainResult::Pending, ChainResult::Success]);
+    let service = FundingService::new(
+        redis.store().await,
+        driver.clone(),
+        config(redis.url.clone()),
+    );
+    let first = service
+        .execute(request("order-123", 12_500_000))
+        .await
+        .unwrap_err();
+    assert_eq!(first.code, "transaction_pending");
+
+    let mut connection = redis.raw_connection().await;
+    let persisted: String = connection
+        .get("machine-funding:idempotency:order-123")
+        .await
+        .unwrap();
+    assert!(persisted.contains("\"serialized_transaction\":\"0x01\""));
+    let ttl: i64 = connection
+        .ttl("machine-funding:idempotency:order-123")
+        .await
+        .unwrap();
+    assert_eq!(ttl, -1);
+
+    let result = service
+        .execute(request("order-123", 12_500_000))
+        .await
+        .unwrap();
+    assert_eq!(result.transaction_hash, format!("0x{:064x}", 1));
+    assert_eq!(driver.counts(), (1, 2));
+}
+
+#[tokio::test]
+async fn reverted_receipt_is_terminal_and_never_rebroadcast() {
+    let redis = TestRedis::start().await;
+    let driver = FakeDriver::new([ChainResult::Reverted, ChainResult::Success]);
+    let service = FundingService::new(
+        redis.store().await,
+        driver.clone(),
+        config(redis.url.clone()),
+    );
+    let first = service
+        .execute(request("order-123", 12_500_000))
+        .await
+        .unwrap_err();
+    let replay = service
+        .execute(request("order-123", 12_500_000))
+        .await
+        .unwrap_err();
+    assert_eq!(first.code, "transaction_reverted");
+    assert_eq!(replay.code, "transaction_reverted");
+    assert_eq!(driver.counts(), (1, 1));
+}
+
+#[tokio::test]
+async fn terminal_broadcast_rejection_returns_422_and_never_rebroadcasts() {
+    let redis = TestRedis::start().await;
+    let driver = FakeDriver::new([
+        ChainResult::Rejected("insufficient funds for gas".into()),
+        ChainResult::Success,
+    ]);
+    let service = FundingService::new(
+        redis.store().await,
+        driver.clone(),
+        config(redis.url.clone()),
+    );
+    let first = service
+        .execute(request("order-123", 12_500_000))
+        .await
+        .unwrap_err();
+    let replay = service
+        .execute(request("order-123", 12_500_000))
+        .await
+        .unwrap_err();
+    assert_eq!(first.status, 422);
+    assert_eq!(first.code, "transaction_rejected");
+    assert_eq!(first.message, "insufficient funds for gas");
+    assert_eq!(replay.code, "transaction_rejected");
+    assert_eq!(driver.counts(), (1, 1));
+}
+
+#[tokio::test]
+async fn enforces_global_budget_atomically() {
+    let redis = TestRedis::start().await;
+    let driver = FakeDriver::new([ChainResult::Success]);
+    let mut limits = config(redis.url.clone());
+    limits.global_susdc_budget = U256::from(20u64);
+    let service = FundingService::new(redis.store().await, driver.clone(), limits);
+    service.execute(request("order-123", 15)).await.unwrap();
+    let error = service.execute(request("order-124", 10)).await.unwrap_err();
+    assert_eq!(error.code, "global_budget_exceeded");
+    assert_eq!(driver.counts(), (1, 1));
+}
+
+#[tokio::test]
+async fn http_routes_require_auth_and_preserve_success_wire() {
+    let redis = TestRedis::start().await;
+    let driver = FakeDriver::new([ChainResult::Success]);
+    let service = FundingService::new(redis.store().await, driver, config(redis.url.clone()));
+    let app = router(service);
+    let body = r#"{"idempotency_key":"order-123","recipient":"0x00000000000000000000000000000000000000A1","amount":"12500000","reason":"order_payout"}"#;
+
+    let unauthorized = app
+        .clone()
+        .oneshot(
+            Request::post("/api/internal/transfers")
+                .header(header::CONTENT_TYPE, "application/json")
+                .body(Body::from(body))
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+    assert_eq!(unauthorized.status(), StatusCode::UNAUTHORIZED);
+
+    let authorized = app
+        .clone()
+        .oneshot(
+            Request::post("/api/internal/transfers")
+                .header(header::CONTENT_TYPE, "application/json")
+                .header(
+                    header::AUTHORIZATION,
+                    "Bearer a-secure-machine-token-with-32-characters",
+                )
+                .body(Body::from(body))
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+    assert_eq!(authorized.status(), StatusCode::OK);
+    let response: serde_json::Value =
+        serde_json::from_slice(&authorized.into_body().collect().await.unwrap().to_bytes())
+            .unwrap();
+    assert_eq!(response["idempotency_key"], "order-123");
+    assert_eq!(response["amount"], "12500000");
+    assert_eq!(response["replayed"], false);
+
+    let liveness = app
+        .clone()
+        .oneshot(
+            Request::get("/api/internal/health")
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+    assert_eq!(liveness.status(), StatusCode::OK);
+    let readiness = app
+        .clone()
+        .oneshot(
+            Request::get("/api/internal/readiness")
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+    assert_eq!(readiness.status(), StatusCode::UNAUTHORIZED);
+    let authenticated_readiness = app
+        .oneshot(
+            Request::get("/api/internal/readiness")
+                .header(
+                    header::AUTHORIZATION,
+                    "Bearer a-secure-machine-token-with-32-characters",
+                )
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+    assert_eq!(authenticated_readiness.status(), StatusCode::OK);
+}


### PR DESCRIPTION
## Summary

- expose authenticated loopback-only sUSDC and native-gas funding endpoints
- sign and submit Seismic transactions through Alloy with receipt reconciliation
- enforce Redis-backed idempotency, atomic budgets, recipient limits, and serialized operator nonces
- validate the chain, faucet contract, signer address, and restricted operator role at startup

## Test plan

- `cargo fmt --all -- --check`
- `cargo clippy --workspace --all-targets --locked -- -D warnings`
- `cargo test --workspace --locked` (18 tests)
- `cargo build --workspace --release --locked`

## Stack

3 of 4. Depends on #38; next is #40. Split from #35.

Fixes SEI-416 — https://linear.app/seismic-systems/issue/SEI-416/3-machine-funding-add-the-authenticated-funding-server