### PR TITLE
Expose authenticated settlement reserve identities

### DIFF
--- a/machine-funding-server/src/http.rs
+++ b/machine-funding-server/src/http.rs
@@ -91,6 +91,14 @@ where
         )
         .route("/api/internal/base/gas", post(base_gas::<S, D, B>))
         .route(
+            "/api/internal/base/settlement",
+            get(base_settlement::<S, D, B>),
+        )
+        .route(
+            "/api/internal/erc20-usdc/settlement",
+            get(erc20_settlement::<S, D, B>),
+        )
+        .route(
             "/api/internal/base/erc20-usdc/transfers",
             post(base_erc20_usdc_transfer::<S, D, B>),
         )
@@ -103,6 +111,49 @@ where
             erc20_usdc,
             base,
         }))
+}
+
+#[derive(Serialize)]
+struct SettlementIdentity {
+    chain_id: u64,
+    token_address: Address,
+    treasury_address: Address,
+}
+
+async fn base_settlement<S: FundingStore, D: ChainDriver, B: ChainDriver>(
+    State(state): State<Arc<RouterState<S, D, B>>>,
+    headers: HeaderMap,
+) -> Result<Json<SettlementIdentity>, ServiceError> {
+    authorize(&headers, &state.legacy.config().token)?;
+    let service = base_service(&state)?;
+    let config = service
+        .config()
+        .base
+        .enabled()
+        .ok_or_else(base_unavailable)?;
+    Ok(Json(SettlementIdentity {
+        chain_id: config.chain_id,
+        token_address: config.token_address,
+        treasury_address: config.reserve_address,
+    }))
+}
+
+async fn erc20_settlement<S: FundingStore, D: ChainDriver, B: ChainDriver>(
+    State(state): State<Arc<RouterState<S, D, B>>>,
+    headers: HeaderMap,
+) -> Result<Json<SettlementIdentity>, ServiceError> {
+    authorize(&headers, &state.legacy.config().token)?;
+    let service = erc20_service(&state)?;
+    let config = service
+        .config()
+        .erc20_usdc
+        .enabled()
+        .ok_or_else(erc20_unavailable)?;
+    Ok(Json(SettlementIdentity {
+        chain_id: service.config().chain_id,
+        token_address: config.token_address,
+        treasury_address: config.faucet_address,
+    }))
 }
 
 async fn transfer<S, D, B>(

--- a/machine-funding-server/tests/redis_semantics.rs
+++ b/machine-funding-server/tests/redis_semantics.rs
@@ -1142,6 +1142,44 @@ async fn json_body(response: axum::response::Response) -> serde_json::Value {
 }
 
 #[tokio::test]
+async fn settlement_identity_is_authenticated_and_uses_the_actual_token_holder() {
+    let redis = TestRedis::start().await;
+    let legacy = FundingService::new(
+        redis.store().await,
+        FakeDriver::new([]),
+        config(redis.url.clone()),
+    );
+    let mut erc20_config = config(redis.url.clone());
+    enable_erc20_usdc(&mut erc20_config);
+    let expected = erc20_config.erc20_usdc.enabled().unwrap().faucet_address;
+    let erc20 = FundingService::new(redis.store().await, FakeDriver::new([]), erc20_config);
+    let app = router_with_erc20(legacy, Erc20FundingService::Enabled(Box::new(erc20)));
+    let path = "/api/internal/erc20-usdc/settlement";
+    let response = app
+        .clone()
+        .oneshot(Request::get(path).body(Body::empty()).unwrap())
+        .await
+        .unwrap();
+    assert_eq!(response.status(), StatusCode::UNAUTHORIZED);
+    let response = app
+        .oneshot(
+            Request::get(path)
+                .header(
+                    header::AUTHORIZATION,
+                    "Bearer a-secure-machine-token-with-32-characters",
+                )
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+    assert_eq!(response.status(), StatusCode::OK);
+    let body = json_body(response).await;
+    assert_eq!(body["treasury_address"], expected.to_string());
+    assert_eq!(body.as_object().unwrap().len(), 3);
+}
+
+#[tokio::test]
 async fn base_routes_preserve_the_machine_funding_wire_and_report_reserves() {
     let redis = TestRedis::start().await;
     let legacy = FundingService::new(
@@ -1160,6 +1198,24 @@ async fn base_routes_preserve_the_machine_funding_wire_and_report_reserves() {
         BaseFundingService::Enabled(Box::new(base)),
     );
     let auth = "Bearer a-secure-machine-token-with-32-characters";
+
+    let identity = app
+        .clone()
+        .oneshot(
+            Request::get("/api/internal/base/settlement")
+                .header(header::AUTHORIZATION, auth)
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+    assert_eq!(identity.status(), StatusCode::OK);
+    let identity = json_body(identity).await;
+    assert_eq!(identity["chain_id"], 84532);
+    assert_eq!(
+        identity["treasury_address"],
+        healthy_reserves().reserve_address.to_lowercase()
+    );
 
     let gas = app
         .clone()


### PR DESCRIPTION
## Summary
Add two authenticated, read-only endpoints exposing the configured chain, token, and address holding payout liquidity.

- `GET /api/internal/base/settlement`: Base chain ID, token address, and reserve wallet.
- `GET /api/internal/erc20-usdc/settlement`: Seismic chain ID, token address, and ERC20 faucet contract (not the admin/reserve EOA).
- Both require the existing machine bearer token and retain existing disabled/unavailable handling.
- No changes to contracts, keys, transfers, budgets, public faucet endpoints, or frontend behavior.

## Verification
- `cargo fmt --all -- --check`
- `cargo clippy --workspace --all-targets -- -D warnings`
- `cargo test --workspace --locked`: 49 tests passed, including Redis-backed route/authentication and reserve identity coverage.

## Compatibility
Additive server update only. No contract redeployment or configuration migration required.

Tracking: [SEI-483](https://linear.app/seismic-systems/issue/SEI-483/3-faucet-expose-authenticated-settlement-reserve-identities).